### PR TITLE
Authoriz

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AC32041C25CC46EF00A68520 /* PowerABView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC32041B25CC46EF00A68520 /* PowerABView.swift */; };
 		AC32041F25CC485E00A68520 /* ConnectingABView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC32041E25CC485E00A68520 /* ConnectingABView.swift */; };
 		AC32043625CD534700A68520 /* ChooseSessionTypeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC32043525CD534700A68520 /* ChooseSessionTypeView.swift */; };
+		AC489B5C2603614E00CEEC48 /* MoreInfoPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC489B5B2603614E00CEEC48 /* MoreInfoPopupView.swift */; };
 		AC4EC6BC25B5ABB700C1E312 /* StatisticsContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4EC6BB25B5ABB700C1E312 /* StatisticsContainerView.swift */; };
 		AC4EC6C125B6F18A00C1E312 /* EditButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4EC6C025B6F18A00C1E312 /* EditButtonView.swift */; };
 		AC4EC6C425B6FE0D00C1E312 /* HeatmapSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4EC6C325B6FE0D00C1E312 /* HeatmapSettingsView.swift */; };
@@ -104,6 +105,7 @@
 		AC32041B25CC46EF00A68520 /* PowerABView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerABView.swift; sourceTree = "<group>"; };
 		AC32041E25CC485E00A68520 /* ConnectingABView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectingABView.swift; sourceTree = "<group>"; };
 		AC32043525CD534700A68520 /* ChooseSessionTypeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseSessionTypeView.swift; sourceTree = "<group>"; };
+		AC489B5B2603614E00CEEC48 /* MoreInfoPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreInfoPopupView.swift; sourceTree = "<group>"; };
 		AC4EC6BB25B5ABB700C1E312 /* StatisticsContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsContainerView.swift; sourceTree = "<group>"; };
 		AC4EC6C025B6F18A00C1E312 /* EditButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditButtonView.swift; sourceTree = "<group>"; };
 		AC4EC6C325B6FE0D00C1E312 /* HeatmapSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapSettingsView.swift; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 			isa = PBXGroup;
 			children = (
 				AC32043525CD534700A68520 /* ChooseSessionTypeView.swift */,
+				AC489B5B2603614E00CEEC48 /* MoreInfoPopupView.swift */,
 				AC86EE6A25D03DC00083F8C0 /* SelectDeviceView.swift */,
 				AC3203CA25CA991C00A68520 /* TurnOnBluetoothView.swift */,
 				AC32041B25CC46EF00A68520 /* PowerABView.swift */,
@@ -633,6 +636,7 @@
 				AC32043625CD534700A68520 /* ChooseSessionTypeView.swift in Sources */,
 				AC7EB37825A6FB3A00A7F2AF /* MainTabBarView.swift in Sources */,
 				AC960C7825DD39F500EC95DD /* ABConnectedView.swift in Sources */,
+				AC489B5C2603614E00CEEC48 /* MoreInfoPopupView.swift in Sources */,
 				AC5832DA25B196DD008C5DD5 /* Graph.swift in Sources */,
 				AC93B8E725BEFE4F003D0A0D /* AirMapView.swift in Sources */,
 				3362B4ED25E69987008D61BA /* AddNameAndTagsView.swift in Sources */,

--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		ACD01F7325FF574A00B8F65F /* WifiPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD01F7225FF574A00B8F65F /* WifiPopupView.swift */; };
 		ACD01F7625FF61CE00B8F65F /* LocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD01F7525FF61CE00B8F65F /* LocationProvider.swift */; };
 		ACD01F7B25FF6C3300B8F65F /* BlueTextButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD01F7A25FF6C3300B8F65F /* BlueTextButtonStyle.swift */; };
+		ACD01F922600A3C800B8F65F /* RootAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD01F912600A3C800B8F65F /* RootAppView.swift */; };
+		ACD01F952600A54400B8F65F /* UserDefaults+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD01F942600A54400B8F65F /* UserDefaults+Preferences.swift */; };
+		ACD32A4F2600A8DD00818946 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD32A4E2600A8DD00818946 /* SettingsView.swift */; };
 		ACF77DF025A750C200BB85B7 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF77DEF25A750C200BB85B7 /* Font.swift */; };
 		ACF77DF425A750E000BB85B7 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF77DF325A750E000BB85B7 /* Color.swift */; };
 		ACF77DF825A866E700BB85B7 /* BlueButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF77DF725A866E700BB85B7 /* BlueButtonStyle.swift */; };
@@ -161,6 +164,9 @@
 		ACD01F7225FF574A00B8F65F /* WifiPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WifiPopupView.swift; sourceTree = "<group>"; };
 		ACD01F7525FF61CE00B8F65F /* LocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProvider.swift; sourceTree = "<group>"; };
 		ACD01F7A25FF6C3300B8F65F /* BlueTextButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueTextButtonStyle.swift; sourceTree = "<group>"; };
+		ACD01F912600A3C800B8F65F /* RootAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootAppView.swift; sourceTree = "<group>"; };
+		ACD01F942600A54400B8F65F /* UserDefaults+Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Preferences.swift"; sourceTree = "<group>"; };
+		ACD32A4E2600A8DD00818946 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		ACF77DEF25A750C200BB85B7 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		ACF77DF325A750E000BB85B7 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		ACF77DF725A866E700BB85B7 /* BlueButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueButtonStyle.swift; sourceTree = "<group>"; };
@@ -225,6 +231,7 @@
 				AC32040325CC067D00A68520 /* CheckBox.swift */,
 				AC4EC6C025B6F18A00C1E312 /* EditButtonView.swift */,
 				AC8CFF4025E5095600FB2918 /* Textfield.swift */,
+				ACD01F942600A54400B8F65F /* UserDefaults+Preferences.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -302,11 +309,13 @@
 			children = (
 				ACD01F6C25FF4C8C00B8F65F /* AirCasting.entitlements */,
 				AC7EB37525A6FB3A00A7F2AF /* AirCastingApp.swift */,
+				ACD01F912600A3C800B8F65F /* RootAppView.swift */,
 				AC7EB37725A6FB3A00A7F2AF /* MainTabBarView.swift */,
 				338C30E025F1042000E0305C /* CoreData */,
 				AC1DAD4325C98556009AC4D1 /* ABConnector */,
 				AC8CFF4325E5108100FB2918 /* Networking */,
 				AC8CFF3425E502C700FB2918 /* Auth */,
+				ACD32A4D2600A8CC00818946 /* Settings */,
 				AC3203CE25CBED9C00A68520 /* Dashboard */,
 				AC32043425CD52E600A68520 /* CreateSessionViews */,
 				AC6D56A825B0837500D221BA /* SessionViews */,
@@ -406,6 +415,14 @@
 				AC8D6C6925C049E300ED74D1 /* Environment.swift */,
 			);
 			path = Map;
+			sourceTree = "<group>";
+		};
+		ACD32A4D2600A8CC00818946 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				ACD32A4E2600A8DD00818946 /* SettingsView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		ACF77DEE25A7502600BB85B7 /* Extensions */ = {
@@ -611,6 +628,7 @@
 				AC6D569A25ADE57800D221BA /* GrayButtonStyle.swift in Sources */,
 				ACF77DF825A866E700BB85B7 /* BlueButtonStyle.swift in Sources */,
 				AC32041F25CC485E00A68520 /* ConnectingABView.swift in Sources */,
+				ACD32A4F2600A8DD00818946 /* SettingsView.swift in Sources */,
 				AC3203CB25CA991C00A68520 /* TurnOnBluetoothView.swift in Sources */,
 				AC32043625CD534700A68520 /* ChooseSessionTypeView.swift in Sources */,
 				AC7EB37825A6FB3A00A7F2AF /* MainTabBarView.swift in Sources */,
@@ -645,6 +663,7 @@
 				ACF77DF425A750E000BB85B7 /* Color.swift in Sources */,
 				AC4EC6C125B6F18A00C1E312 /* EditButtonView.swift in Sources */,
 				AC6D567F25AC54A400D221BA /* ChartView.swift in Sources */,
+				ACD01F952600A54400B8F65F /* UserDefaults+Preferences.swift in Sources */,
 				AC4EC6BC25B5ABB700C1E312 /* StatisticsContainerView.swift in Sources */,
 				AC8CFF3625E502DD00FB2918 /* CreateAccountView.swift in Sources */,
 				338C30E825F10BFE00E0305C /* AirCasting.xcdatamodeld in Sources */,
@@ -655,6 +674,7 @@
 				AC8CFF4525E510CB00FB2918 /* AuthorizationAPI.swift in Sources */,
 				AC8CFF4125E5095600FB2918 /* Textfield.swift in Sources */,
 				AC7EB37625A6FB3A00A7F2AF /* AirCastingApp.swift in Sources */,
+				ACD01F922600A3C800B8F65F /* RootAppView.swift in Sources */,
 				331EA80A25E32094009DEFDB /* ConfirmCreatingSessionView.swift in Sources */,
 				ACF77DF025A750C200BB85B7 /* Font.swift in Sources */,
 				ACD01F7325FF574A00B8F65F /* WifiPopupView.swift in Sources */,
@@ -789,7 +809,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"AirCasting/Preview Content\"";
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
@@ -816,7 +836,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_ASSET_PATHS = "\"AirCasting/Preview Content\"";
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;

--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -813,7 +813,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"AirCasting/Preview Content\"";
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
@@ -840,7 +840,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"AirCasting/Preview Content\"";
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;

--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				338C30E025F1042000E0305C /* CoreData */,
 				AC1DAD4325C98556009AC4D1 /* ABConnector */,
 				AC8CFF4325E5108100FB2918 /* Networking */,
-				AC8CFF3425E502C700FB2918 /* Auth */,
+				AC8CFF3425E502C700FB2918 /* AuthViews */,
 				ACD32A4D2600A8CC00818946 /* Settings */,
 				AC3203CE25CBED9C00A68520 /* Dashboard */,
 				AC32043425CD52E600A68520 /* CreateSessionViews */,
@@ -380,13 +380,13 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
-		AC8CFF3425E502C700FB2918 /* Auth */ = {
+		AC8CFF3425E502C700FB2918 /* AuthViews */ = {
 			isa = PBXGroup;
 			children = (
 				AC8CFF3525E502DD00FB2918 /* CreateAccountView.swift */,
 				AC8CFF5B25E6866100FB2918 /* SignInView.swift */,
 			);
-			path = Auth;
+			path = AuthViews;
 			sourceTree = "<group>";
 		};
 		AC8CFF4325E5108100FB2918 /* Networking */ = {

--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -10,7 +10,18 @@ import CoreBluetooth
 
 class BluetoothManager: NSObject, ObservableObject {
     
-    var centralManager = CBCentralManager()
+    lazy var centralManager: CBCentralManager = {
+        let centralManager = CBCentralManager()
+        
+        centralManager.delegate = self
+        isScanning = centralManager.isScanning
+
+        observed = centralManager.observe(\.isScanning) { [weak self] _, change in
+            self?.isScanning = self?.centralManager.isScanning ?? false
+        }
+        
+        return centralManager
+    }()
     @Published var devices: [CBPeripheral] = []
     @Published var isScanning: Bool = true
     var observed: NSKeyValueObservation?
@@ -30,16 +41,6 @@ class BluetoothManager: NSObject, ObservableObject {
     var otherDevices: [CBPeripheral] {
         devices.filter { (device) -> Bool in
             !(device.name?.contains("AirBeam") ?? false)
-        }
-    }
-    
-    override init() {
-        super.init()
-        centralManager.delegate = self
-        isScanning = centralManager.isScanning
-        
-        observed = centralManager.observe(\.isScanning) { [weak self] _, change in
-            self?.isScanning = self?.centralManager.isScanning ?? false
         }
     }
     

--- a/AirCasting/ABConnector/BluetoothManager.swift
+++ b/AirCasting/ABConnector/BluetoothManager.swift
@@ -12,18 +12,17 @@ class BluetoothManager: NSObject, ObservableObject {
     
     lazy var centralManager: CBCentralManager = {
         let centralManager = CBCentralManager()
-        
         centralManager.delegate = self
         isScanning = centralManager.isScanning
-
         observed = centralManager.observe(\.isScanning) { [weak self] _, change in
             self?.isScanning = self?.centralManager.isScanning ?? false
         }
-        
         return centralManager
     }()
+    
     @Published var devices: [CBPeripheral] = []
     @Published var isScanning: Bool = true
+    @Published var centralManagerState: CBManagerState = .unknown
     var observed: NSKeyValueObservation?
     
     private var MEASUREMENTS_CHARACTERISTIC_UUIDS: [CBUUID] = [
@@ -57,8 +56,9 @@ class BluetoothManager: NSObject, ObservableObject {
 }
 
 extension BluetoothManager: CBCentralManagerDelegate {
-    
+        
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        centralManagerState = central.state
         
         switch central.state {
         case .unknown:

--- a/AirCasting/AirCastingApp.swift
+++ b/AirCasting/AirCastingApp.swift
@@ -6,57 +6,13 @@
 //
 
 import SwiftUI
-import Firebase
 
 @main
 struct AirCastingApp: App {
-
-    let persistenceController = PersistenceController.shared
-    let userDefaults = UserDefaults.standard
-    @ObservedObject var bluetoothManager = BluetoothManager()
-    @State var test: Any?
     
     var body: some Scene {
         WindowGroup {
-            MainTabBarView()
-                .onAppear {
-                    FirebaseApp.configure()
-                    
-                    test = AuthorizationAPI
-                        .signIn(input: AuthorizationAPI.SigninUserInput(username: "bilbo123",
-                                                                        password: "baggins123"))
-                        .sink(receiveCompletion: { (compl) in
-                            print("Compl.")
-                            switch compl {
-                            case .failure(let error):
-                                print(error.localizedDescription)
-                            case .finished:
-                                print("Donee")
-                            }
-                        }, receiveValue: { (output) in
-                            userDefaults.set(output.authentication_token, forKey: "auth_token")
-                            print(output)
-                        })
-                    
-                    return;
-                       
-                    print("Strating api...")
-                    test = CreateSessionApi().createEmptyFixedWifiSession(input: .mock)
-                        .sink(receiveCompletion: { (completion) in
-                            switch completion {
-                            case .failure(let error):
-                                print(error.localizedDescription)
-                            case .finished:
-                                print("OK")
-                            }
-                            print("End.")
-                        }, receiveValue: { (output) in
-                            print(output)
-                            print("...")
-                        })
-                }
-                .environmentObject(bluetoothManager)
-                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+            RootAppView()
         }
     }
 }

--- a/AirCasting/Auth/CreateAccountView.swift
+++ b/AirCasting/Auth/CreateAccountView.swift
@@ -13,7 +13,6 @@ struct CreateAccountView: View {
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var task: Any?
-    @State private var isAccountCreated = false
     
     var body: some View {
             VStack(spacing: 50) {
@@ -75,7 +74,6 @@ struct CreateAccountView: View {
                     switch completion {
                     case .finished:
                         print("Success")
-                        isAccountCreated = true
                     case .failure(let error):
                         print("ERROR: \(error)")
                     }
@@ -85,14 +83,6 @@ struct CreateAccountView: View {
             
         }
         .buttonStyle(BlueButtonStyle())
-        .background( Group {
-            NavigationLink(
-                destination: RootAppView(),
-                isActive: $isAccountCreated,
-                label: {
-                    EmptyView()
-                })
-        })
     }
     
     var signinButton: some View {

--- a/AirCasting/Auth/CreateAccountView.swift
+++ b/AirCasting/Auth/CreateAccountView.swift
@@ -13,13 +13,14 @@ struct CreateAccountView: View {
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var task: Any?
+    @State private var isAccountCreated = false
     
     var body: some View {
-        NavigationView {
             VStack(spacing: 50) {
                 titleLabel
                 VStack(spacing: 20) {
                     emailTextfield
+                        .keyboardType(.emailAddress)
                     usernameTextfield
                     passwordTextfield
                 }
@@ -30,7 +31,6 @@ struct CreateAccountView: View {
             }
             .padding()
             .navigationBarHidden(true)
-        }
     }
     
     var titleLabel: some View {
@@ -39,7 +39,7 @@ struct CreateAccountView: View {
                 .font(Font.moderate(size: 32,
                                     weight: .bold))
                 .foregroundColor(.accentColor)
-            Text("to record and map your envitonment")
+            Text("to record and map your environment")
                 .font(Font.muli(size: 16))
                 .foregroundColor(.aircastingGray)
         }
@@ -49,6 +49,7 @@ struct CreateAccountView: View {
         createTextfield(placeholder: "Email",
                         binding: $email)
     }
+    
     var usernameTextfield: some View {
         createTextfield(placeholder: "Username",
                         binding: $username)
@@ -74,15 +75,24 @@ struct CreateAccountView: View {
                     switch completion {
                     case .finished:
                         print("Success")
+                        isAccountCreated = true
                     case .failure(let error):
                         print("ERROR: \(error)")
                     }
                 } receiveValue: { (output) in
-                    print(output)
+                    UserDefaults.authToken = output.authentication_token
                 }
             
         }
         .buttonStyle(BlueButtonStyle())
+        .background( Group {
+            NavigationLink(
+                destination: RootAppView(),
+                isActive: $isAccountCreated,
+                label: {
+                    EmptyView()
+                })
+        })
     }
     
     var signinButton: some View {

--- a/AirCasting/Auth/SignInView.swift
+++ b/AirCasting/Auth/SignInView.swift
@@ -12,7 +12,6 @@ struct SignInView: View {
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var task: Any?
-    @State private var isUserLoggedIn = false
     
     var body: some View {
             VStack(spacing: 40) {
@@ -68,14 +67,6 @@ struct SignInView: View {
                 }
         }
         .buttonStyle(BlueButtonStyle())
-        .background( Group {
-            NavigationLink(
-                destination: RootAppView(),
-                isActive: $isUserLoggedIn,
-                label: {
-                    EmptyView()
-                })
-        })
     }
     
     var signupButton: some View {

--- a/AirCasting/Auth/SignInView.swift
+++ b/AirCasting/Auth/SignInView.swift
@@ -12,6 +12,7 @@ struct SignInView: View {
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var task: Any?
+    @State private var isUserLoggedIn = false
     
     var body: some View {
             VStack(spacing: 40) {
@@ -62,16 +63,24 @@ struct SignInView: View {
                         print("ERROR: \(error)")
                     }
                 } receiveValue: { (output) in
+                    UserDefaults.authToken = output.authentication_token
                     print(output)
                 }
-            
         }
         .buttonStyle(BlueButtonStyle())
+        .background( Group {
+            NavigationLink(
+                destination: RootAppView(),
+                isActive: $isUserLoggedIn,
+                label: {
+                    EmptyView()
+                })
+        })
     }
     
     var signupButton: some View {
         NavigationLink(
-            destination: SignInView(),
+            destination: CreateAccountView(),
             label: {
                 signupButtonText
             })

--- a/AirCasting/AuthViews/CreateAccountView.swift
+++ b/AirCasting/AuthViews/CreateAccountView.swift
@@ -1,27 +1,32 @@
 //
-//  SignInView.swift
+//  CreateAccountView.swift
 //  AirCasting
 //
-//  Created by Lunar on 24/02/2021.
+//  Created by Lunar on 23/02/2021.
 //
 
 import SwiftUI
 
-struct SignInView: View {
+struct CreateAccountView: View {
     
+    @State private var email: String = ""
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var task: Any?
     
     var body: some View {
-            VStack(spacing: 40) {
+            VStack(spacing: 50) {
                 titleLabel
                 VStack(spacing: 20) {
+                    emailTextfield
+                        .keyboardType(.emailAddress)
                     usernameTextfield
                     passwordTextfield
                 }
-                signinButton
-                signupButton
+                VStack(spacing: 25) {
+                    createAccountButton
+                    signinButton
+                }
             }
             .padding()
             .navigationBarHidden(true)
@@ -29,7 +34,7 @@ struct SignInView: View {
     
     var titleLabel: some View {
         VStack(alignment: .leading, spacing: 15) {
-            Text("Sign in")
+            Text("Create account")
                 .font(Font.moderate(size: 32,
                                     weight: .bold))
                 .foregroundColor(.accentColor)
@@ -39,9 +44,16 @@ struct SignInView: View {
         }
     }
     
+    var emailTextfield: some View {
+        createTextfield(placeholder: "Email",
+                        binding: $email)
+            .autocapitalization(.none)
+    }
+    
     var usernameTextfield: some View {
         createTextfield(placeholder: "Username",
                         binding: $username)
+            .autocapitalization(.none)
     }
     var passwordTextfield: some View {
         SecureField("Password", text: $password)
@@ -50,10 +62,16 @@ struct SignInView: View {
             .background(Color.aircastingGray.opacity(0.05))
             .border(Color.aircastingGray.opacity(0.1))
     }
-    var signinButton: some View {
-        Button("Sign in") {
-            task = AuthorizationAPI.signIn(input: AuthorizationAPI.SigninUserInput(username: username,
-                                                                            password: password))
+    
+    var createAccountButton: some View {
+        Button("Continue") {
+            let userInfo = AuthorizationAPI.SignupUserInput(email: email,
+                                                      username: username,
+                                                      password: password,
+                                                      send_emails: false)
+            let userInput = AuthorizationAPI.SignupAPIInput(user: userInfo)
+            
+            task = AuthorizationAPI.createAccount(input: userInput)
                 .sink { (completion) in
                     switch completion {
                     case .finished:
@@ -63,33 +81,33 @@ struct SignInView: View {
                     }
                 } receiveValue: { (output) in
                     UserDefaults.authToken = output.authentication_token
-                    print(output)
                 }
+            
         }
         .buttonStyle(BlueButtonStyle())
     }
     
-    var signupButton: some View {
+    var signinButton: some View {
         NavigationLink(
-            destination: CreateAccountView(),
+            destination: SignInView(),
             label: {
-                signupButtonText
+                signingButtonText
             })
     }
     
-    var signupButtonText: some View {
-        Text("First time here? ")
+    var signingButtonText: some View {
+        Text("Already have an account? ")
             .font(Font.muli(size: 16))
             .foregroundColor(.aircastingGray)
             
-            + Text("Create an account")
+            + Text("Sign in")
             .font(Font.moderate(size: 16, weight: .bold))
             .foregroundColor(.accentColor)
     }
 }
 
-struct SignInView_Previews: PreviewProvider {
+struct CreateAccountView_Previews: PreviewProvider {
     static var previews: some View {
-        SignInView()
+        CreateAccountView()
     }
 }

--- a/AirCasting/AuthViews/SignInView.swift
+++ b/AirCasting/AuthViews/SignInView.swift
@@ -1,32 +1,27 @@
 //
-//  CreateAccountView.swift
+//  SignInView.swift
 //  AirCasting
 //
-//  Created by Lunar on 23/02/2021.
+//  Created by Lunar on 24/02/2021.
 //
 
 import SwiftUI
 
-struct CreateAccountView: View {
+struct SignInView: View {
     
-    @State private var email: String = ""
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var task: Any?
     
     var body: some View {
-            VStack(spacing: 50) {
+            VStack(spacing: 40) {
                 titleLabel
                 VStack(spacing: 20) {
-                    emailTextfield
-                        .keyboardType(.emailAddress)
                     usernameTextfield
                     passwordTextfield
                 }
-                VStack(spacing: 25) {
-                    createAccountButton
-                    signinButton
-                }
+                signinButton
+                signupButton
             }
             .padding()
             .navigationBarHidden(true)
@@ -34,7 +29,7 @@ struct CreateAccountView: View {
     
     var titleLabel: some View {
         VStack(alignment: .leading, spacing: 15) {
-            Text("Create account")
+            Text("Sign in")
                 .font(Font.moderate(size: 32,
                                     weight: .bold))
                 .foregroundColor(.accentColor)
@@ -44,14 +39,10 @@ struct CreateAccountView: View {
         }
     }
     
-    var emailTextfield: some View {
-        createTextfield(placeholder: "Email",
-                        binding: $email)
-    }
-    
     var usernameTextfield: some View {
         createTextfield(placeholder: "Username",
                         binding: $username)
+            .autocapitalization(.none)
     }
     var passwordTextfield: some View {
         SecureField("Password", text: $password)
@@ -60,16 +51,10 @@ struct CreateAccountView: View {
             .background(Color.aircastingGray.opacity(0.05))
             .border(Color.aircastingGray.opacity(0.1))
     }
-    
-    var createAccountButton: some View {
-        Button("Continue") {
-            let userInfo = AuthorizationAPI.SignupUserInput(email: email,
-                                                      username: username,
-                                                      password: password,
-                                                      send_emails: false)
-            let userInput = AuthorizationAPI.SignupAPIInput(user: userInfo)
-            
-            task = AuthorizationAPI.createAccount(input: userInput)
+    var signinButton: some View {
+        Button("Sign in") {
+            task = AuthorizationAPI.signIn(input: AuthorizationAPI.SigninUserInput(username: username,
+                                                                            password: password))
                 .sink { (completion) in
                     switch completion {
                     case .finished:
@@ -79,33 +64,33 @@ struct CreateAccountView: View {
                     }
                 } receiveValue: { (output) in
                     UserDefaults.authToken = output.authentication_token
+                    print(output)
                 }
-            
         }
         .buttonStyle(BlueButtonStyle())
     }
     
-    var signinButton: some View {
+    var signupButton: some View {
         NavigationLink(
-            destination: SignInView(),
+            destination: CreateAccountView(),
             label: {
-                signingButtonText
+                signupButtonText
             })
     }
     
-    var signingButtonText: some View {
-        Text("Already have an account? ")
+    var signupButtonText: some View {
+        Text("First time here? ")
             .font(Font.muli(size: 16))
             .foregroundColor(.aircastingGray)
             
-            + Text("Sign in")
+            + Text("Create an account")
             .font(Font.moderate(size: 16, weight: .bold))
             .foregroundColor(.accentColor)
     }
 }
 
-struct CreateAccountView_Previews: PreviewProvider {
+struct SignInView_Previews: PreviewProvider {
     static var previews: some View {
-        CreateAccountView()
+        SignInView()
     }
 }

--- a/AirCasting/CreateSessionViews/AddNameAndTagsView.swift
+++ b/AirCasting/CreateSessionViews/AddNameAndTagsView.swift
@@ -18,22 +18,37 @@ struct AddNameAndTagsView: View {
     @State var wifiSSID: String = ""
     @State private var isConfirmCreatingSessionActive: Bool = false
     @EnvironmentObject private var sessionContext: CreateSessionContext
-
+    
     var body: some View {
-        VStack(spacing: 100) {
-            VStack(alignment: .leading, spacing: 30) {
-                ProgressView(value: 0.75)
-                titleLabel
-                VStack(spacing: 20) {
-                    createTextfield(placeholder: "Session name", binding: $sessionName)
-                    createTextfield(placeholder: "Tags", binding: $sessionTags)
+        GeometryReader { geometry in
+            ScrollView(.vertical) {
+                VStack {
+                    VStack(alignment: .leading, spacing: 30) {
+                        ProgressView(value: 0.75)
+                        titleLabel
+                        VStack(spacing: 20) {
+                            createTextfield(placeholder: "Session name", binding: $sessionName)
+                            createTextfield(placeholder: "Tags", binding: $sessionTags)
+                        }
+                        if sessionContext.sessionType == SessionType.FIXED {
+                            placementPicker
+                            transmissionTypePicker
+                        }
+                    }
+                    Spacer()
+                    continueButton
                 }
-                placementPicker
-                transmissionTypePicker
+                .padding()
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
             }
-            continueButton
         }
-        .padding()
+        //        .simultaneousGesture(
+        //
+//            DragGesture(minimumDistance: 2, coordinateSpace: .global)
+//                .onChanged({ (_) in
+//                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+//                })
+//        )
     }
     
     var continueButton: some View {

--- a/AirCasting/CreateSessionViews/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionTypeView.swift
@@ -15,6 +15,7 @@ struct ChooseSessionTypeView: View {
     @StateObject var sessionContext = CreateSessionContext()
     @State private var isFixedNavigationLinkActive = false
     @State private var isMobileNavigationLinkActive = false
+    @EnvironmentObject var bluetoothManager: BluetoothManager
     
     var body: some View {
         NavigationView {
@@ -92,10 +93,21 @@ struct ChooseSessionTypeView: View {
             fixedSessionLabel
         }
         .background(
-            NavigationLink(destination: TurnOnBluetoothView(),
-                           isActive: $isFixedNavigationLinkActive) {
-                EmptyView()
-            })
+            Group {
+                if CBCentralManager.authorization == .allowedAlways &&
+                    bluetoothManager.centralManager.state == .poweredOn {
+                    NavigationLink(destination: PowerABView(),
+                                   isActive: $isFixedNavigationLinkActive) {
+                        EmptyView()
+                    }
+                } else {
+                    NavigationLink(destination: TurnOnBluetoothView(),
+                                   isActive: $isFixedNavigationLinkActive) {
+                        EmptyView()
+                    }
+                }
+            }
+        )
     }
     
     var mobileSessionButton: some View {

--- a/AirCasting/CreateSessionViews/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionTypeView.swift
@@ -52,6 +52,9 @@ struct ChooseSessionTypeView: View {
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 sessionContext.managedObjectContext = context
+                if CBCentralManager.authorization == .allowedAlways {
+                    _ = bluetoothManager.centralManager
+                }
             }
             .onChange(of: bluetoothManager.centralManagerState) { (state) in
                 if didTapFixedSession {

--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -14,7 +14,7 @@ struct ConfirmCreatingSessionView: View {
     var sessionName: String
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 50) {
+        VStack(alignment: .leading, spacing: 40) {
             Text("Are you ready?")
                 .font(Font.moderate(size: 24, weight: .bold))
                 .foregroundColor(.darkBlue)

--- a/AirCasting/CreateSessionViews/MoreInfoPopupView.swift
+++ b/AirCasting/CreateSessionViews/MoreInfoPopupView.swift
@@ -1,0 +1,30 @@
+//
+//  MoreInfoPopupView.swift
+//  AirCasting
+//
+//  Created by Lunar on 18/03/2021.
+//
+
+import SwiftUI
+
+struct MoreInfoPopupView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 25) {
+            Text("Session types")
+                .font(Font.moderate(size: 28, weight: .bold))
+                .foregroundColor(.accentColor)
+            Text("If you plan on moving around with the AirBeam3 while recording air quality measurement, configure the AirBeam to record a mobile session. When recording a mobile AirCasting session, measurements are created, timestamped, and geolocated once per second.")
+            Text("If you plan to leave the AirBeam3 indoors or hang it outside then configure it to record a fixed session. When recording fixed AirCasting sessions, measurements are created and timestamped once per minute, and geocoordinates are fixed to a set location.")
+        }
+        .font(Font.muli(size: 16))
+        .lineSpacing(12)
+        .foregroundColor(.aircastingGray)
+        .padding()
+    }
+}
+
+struct MoreInfoPopupView_Previews: PreviewProvider {
+    static var previews: some View {
+        MoreInfoPopupView()
+    }
+}

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CoreBluetooth
 
 struct SelectDeviceView: View {
     
@@ -13,6 +14,7 @@ struct SelectDeviceView: View {
     @State private var isBluetoothLinkActive: Bool = false
     @State private var isMicLinkActive: Bool = false
     @EnvironmentObject private var sessionContext: CreateSessionContext
+    @EnvironmentObject var bluetoothManager: BluetoothManager
     
     var body: some View {
         VStack(spacing: 30) {
@@ -89,6 +91,21 @@ struct SelectDeviceView: View {
         })
         .buttonStyle(BlueButtonStyle())
         .background( Group {
+                Group {
+                    if CBCentralManager.authorization == .allowedAlways &&
+                        bluetoothManager.centralManager.state == .poweredOn {
+                        NavigationLink(destination: PowerABView(),
+                                       isActive: $isBluetoothLinkActive) {
+                            EmptyView()
+                        }
+                    } else {
+                        NavigationLink(destination: TurnOnBluetoothView(),
+                                       isActive: $isBluetoothLinkActive) {
+                            EmptyView()
+                        }
+                    }
+                }
+        
             NavigationLink(
                 destination: TurnOnBluetoothView(),
                 isActive: $isBluetoothLinkActive,

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -86,9 +86,9 @@ struct SelectDeviceView: View {
             if selected == 1 {
                 if CBCentralManager.authorization == .allowedAlways &&
                     bluetoothManager.centralManager.state == .poweredOn {
-                    isTurnOnBluetoothLinkActive = true
-                } else {
                     isPowerABLinkActive = true
+                } else {
+                    isTurnOnBluetoothLinkActive = true
                 }
             } else if selected == 2 {
                 isMicLinkActive = true

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -11,7 +11,8 @@ import CoreBluetooth
 struct SelectDeviceView: View {
     
     @State private var selected = 0
-    @State private var isBluetoothLinkActive: Bool = false
+    @State private var isTurnOnBluetoothLinkActive: Bool = false
+    @State private var isPowerABLinkActive: Bool = false
     @State private var isMicLinkActive: Bool = false
     @EnvironmentObject private var sessionContext: CreateSessionContext
     @EnvironmentObject var bluetoothManager: BluetoothManager
@@ -41,6 +42,7 @@ struct SelectDeviceView: View {
             selected = 1
             // it doesn't have to be airbeam, it can be any device, but it doesn't influence anything, it's just needed for views flow
             sessionContext.deviceType = DeviceType.AIRBEAM3
+            _ = bluetoothManager.centralManager
         }, label: {
             bluetoothLabels
         })
@@ -82,7 +84,12 @@ struct SelectDeviceView: View {
     var chooseButton: some View {
         Button(action: {
             if selected == 1 {
-                isBluetoothLinkActive = true
+                if CBCentralManager.authorization == .allowedAlways &&
+                    bluetoothManager.centralManager.state == .poweredOn {
+                    isTurnOnBluetoothLinkActive = true
+                } else {
+                    isPowerABLinkActive = true
+                }
             } else if selected == 2 {
                 isMicLinkActive = true
             }
@@ -91,24 +98,15 @@ struct SelectDeviceView: View {
         })
         .buttonStyle(BlueButtonStyle())
         .background( Group {
-                Group {
-                    if CBCentralManager.authorization == .allowedAlways &&
-                        bluetoothManager.centralManager.state == .poweredOn {
-                        NavigationLink(destination: PowerABView(),
-                                       isActive: $isBluetoothLinkActive) {
-                            EmptyView()
-                        }
-                    } else {
-                        NavigationLink(destination: TurnOnBluetoothView(),
-                                       isActive: $isBluetoothLinkActive) {
-                            EmptyView()
-                        }
-                    }
-                }
-        
+            NavigationLink(
+                destination: PowerABView(),
+                isActive: $isPowerABLinkActive,
+                label: {
+                    EmptyView()
+                })
             NavigationLink(
                 destination: TurnOnBluetoothView(),
-                isActive: $isBluetoothLinkActive,
+                isActive: $isTurnOnBluetoothLinkActive,
                 label: {
                     EmptyView()
                 })

--- a/AirCasting/CreateSessionViews/SelectPeripheralView.swift
+++ b/AirCasting/CreateSessionViews/SelectPeripheralView.swift
@@ -15,48 +15,53 @@ struct SelectPeripheralView: View {
     @EnvironmentObject var sessionContext: CreateSessionContext
     
     var body: some View {
-        VStack(spacing: 30) {
-            ProgressView(value: 0.375)
-            titileLabel
-            
-            LazyVStack(alignment: .leading, spacing: 25) {
-                
-                HStack(spacing: 8) {
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: 30) {
+                    ProgressView(value: 0.375)
+                    titileLabel
                     
-                    Text("AirBeams")
-                    if bluetoothManager.isScanning {
-                        loader
+                    LazyVStack(alignment: .leading, spacing: 25) {
+                        
+                        HStack(spacing: 8) {
+                            Text("AirBeams")
+                            if bluetoothManager.isScanning {
+                                loader
+                            }
+                        }
+                        displayDeviceButton(devices: bluetoothManager.airbeams)
+                        
+                        HStack(spacing: 8) {
+                            Text("Other devices")
+                            if bluetoothManager.isScanning {
+                                loader
+                            }
+                        }
+                        displayDeviceButton(devices: bluetoothManager.otherDevices)
+                    }
+                    .listStyle(PlainListStyle())
+                    .listItemTint(Color.red)
+                    .font(Font.moderate(size: 18, weight: .regular))
+                    .foregroundColor(.aircastingDarkGray)
+                    
+                    Spacer()
+                    
+                    if !bluetoothManager.isScanning {
+                        refreshButton
+                            .frame(alignment: .trailing)
+                    }
+                    
+                    if selection != nil {
+                        connectButton.disabled(false)
+                    } else {
+                        connectButton.disabled(true)
                     }
                 }
-                displayDeviceButton(devices: bluetoothManager.airbeams)
-
-                HStack(spacing: 8) {
-                    Text("Other devices")
-                    if bluetoothManager.isScanning {
-                        loader
-                    }
-                }
-                displayDeviceButton(devices: bluetoothManager.otherDevices)
-            }
-            .listStyle(PlainListStyle())
-            .listItemTint(Color.red)
-            .font(Font.moderate(size: 18, weight: .regular))
-            .foregroundColor(.aircastingDarkGray)
-            
-            Spacer()
-        
-            if !bluetoothManager.isScanning {
-                refreshButton
-                    .frame(alignment: .trailing)
-            }
-
-            if selection != nil {
-                connectButton.disabled(false)
-            } else {
-                connectButton.disabled(true)
+                .padding()
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
             }
         }
-        .padding()
+        
     }
     
     func displayDeviceButton(devices: [CBPeripheral]) -> some View {

--- a/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnBluetoothView.swift
@@ -6,8 +6,13 @@
 //
 
 import SwiftUI
+import CoreBluetooth
 
 struct TurnOnBluetoothView: View {
+    
+    @State private var isPowerABLinkActive = false
+    @EnvironmentObject var bluetoothManager: BluetoothManager
+    
     var body: some View {
         VStack(spacing: 50) {
             ProgressView(value: 0.125)
@@ -35,10 +40,46 @@ struct TurnOnBluetoothView: View {
             .foregroundColor(.aircastingGray)
             .lineSpacing(10.0)
     }
+    
     var continueButton: some View {
-        NavigationLink(destination: PowerABView()) {
+        Button(action: {
+            if CBCentralManager.authorization != .allowedAlways {
+                goToBluetoothAuthSettings()
+            } else {
+                if bluetoothManager.centralManager.state != .poweredOn {
+                    goToBluetoothSettings()
+                } else {
+                    isPowerABLinkActive = true
+                }
+            }
+        }, label: {
             Text("Continue")
-                .frame(maxWidth: .infinity)
+        })
+        .frame(maxWidth: .infinity)
+        .buttonStyle(BlueButtonStyle())
+        .background(
+            NavigationLink(
+                destination: PowerABView(),
+                isActive: $isPowerABLinkActive,
+                label: {
+                    EmptyView()
+                })
+        )}
+    
+    func goToBluetoothSettings() {
+        if let url = URL(string: "App-prefs:root=Bluetooth") {
+            let app = UIApplication.shared
+            if app.canOpenURL(url) {
+                app.open(url, options: [:], completionHandler: nil)
+            }
+        }
+    }
+    func goToBluetoothAuthSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            let app = UIApplication.shared
+            if app.canOpenURL(url) {
+                app.open(url, options: [:], completionHandler: nil)
+            }
         }
     }
 }

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -36,7 +36,6 @@ struct DashboardView: View {
         .navigationBarTitle("Dashboard")
     }
     
-    
     var sectionPicker: some View {
         Picker(selection: .constant(1), label: Text("Picker"), content: {
             Text("Following").tag(1)

--- a/AirCasting/Info.plist
+++ b/AirCasting/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>We need Bluetooth to connect with AirBeam, it&apos;s impossible to collect the data without it. </string>
+	<string>We need Bluetooth to connect with AirBeam, it's impossible to collect the data without it. </string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>AirCasting uses location to show pollution level on the map.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/AirCasting/Info.plist
+++ b/AirCasting/Info.plist
@@ -20,6 +20,23 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>aircasting.org</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>AirCasting uses Bluetooth to connect with AirBeam.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>AirCasting uses location to show pollution level on the map.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
@@ -66,23 +83,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>AirCasting uses Bluetooth to connect with AirBeam.</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>aircasting.org</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/AirCasting/Info.plist
+++ b/AirCasting/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>AirCasting uses Bluetooth to connect with AirBeam.</string>
+	<string>We need Bluetooth to connect with AirBeam, it&apos;s impossible to collect the data without it. </string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>AirCasting uses location to show pollution level on the map.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -35,7 +35,7 @@ struct MainTabBarView: View {
         }
     }
     private var settingsTab: some View {
-        Color.aircastingGray
+        SettingsView()
             .tabItem {
                 Image(systemName: "gearshape")
             }

--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Firebase
 
 struct MainTabBarView: View {
 

--- a/AirCasting/Models/SessionContext.swift
+++ b/AirCasting/Models/SessionContext.swift
@@ -53,6 +53,8 @@ class CreateSessionContext: ObservableObject {
         session.longitude = startingLocation.longitude
         session.latitude = startingLocation.latitude
         
+        // TO DO: Save context to database
+        
         // TO DO: Replace mocked location and date
         let temporaryMockedDate = "19/12/19-02:40:00"
         

--- a/AirCasting/Networking/AuthorizationAPI.swift
+++ b/AirCasting/Networking/AuthorizationAPI.swift
@@ -73,5 +73,4 @@ class AuthorizationAPI {
             }
             .eraseToAnyPublisher()
     }
-    
 }

--- a/AirCasting/Networking/CreateSessionAPI.swift
+++ b/AirCasting/Networking/CreateSessionAPI.swift
@@ -132,5 +132,4 @@ extension CreateSessionApi.Input {
         let input = CreateSessionApi.Input(session: session, compression: true)
         return input
     }
-    
 }

--- a/AirCasting/RootAppView.swift
+++ b/AirCasting/RootAppView.swift
@@ -1,0 +1,43 @@
+//
+//  RootAppView.swift
+//  AirCasting
+//
+//  Created by Lunar on 16/03/2021.
+//
+
+import SwiftUI
+import Firebase
+
+struct RootAppView: View {
+    
+    let persistenceController = PersistenceController.shared
+    @ObservedObject var bluetoothManager = BluetoothManager()
+    @AppStorage(UserDefaults.AUTH_TOKEN_KEY) var authToken: String?
+    var isLoggedIn: Bool { authToken != nil }
+    
+    
+    var body: some View {
+        NavigationView {
+            if isLoggedIn {
+                mainAppView
+            } else {
+                SignInView()
+            }
+        }
+    }
+    
+    var mainAppView: some View {
+        MainTabBarView()
+            .onAppear {
+                FirebaseApp.configure()
+            }
+            .environmentObject(bluetoothManager)
+            .environment(\.managedObjectContext, persistenceController.container.viewContext)
+    }
+}
+
+struct RootAppView_Previews: PreviewProvider {
+    static var previews: some View {
+        RootAppView()
+    }
+}

--- a/AirCasting/RootAppView.swift
+++ b/AirCasting/RootAppView.swift
@@ -15,12 +15,11 @@ struct RootAppView: View {
     @AppStorage(UserDefaults.AUTH_TOKEN_KEY) var authToken: String?
     var isLoggedIn: Bool { authToken != nil }
     
-    
     var body: some View {
-        NavigationView {
-            if isLoggedIn {
-                mainAppView
-            } else {
+        if isLoggedIn {
+            mainAppView
+        } else {
+            NavigationView {
                 SignInView()
             }
         }
@@ -29,7 +28,9 @@ struct RootAppView: View {
     var mainAppView: some View {
         MainTabBarView()
             .onAppear {
-                FirebaseApp.configure()
+                if FirebaseApp.app() == nil {
+                    FirebaseApp.configure()
+                }
             }
             .environmentObject(bluetoothManager)
             .environment(\.managedObjectContext, persistenceController.container.viewContext)

--- a/AirCasting/Settings/SettingsView.swift
+++ b/AirCasting/Settings/SettingsView.swift
@@ -1,0 +1,33 @@
+//
+//  LogoutView.swift
+//  AirCasting
+//
+//  Created by Lunar on 16/03/2021.
+//
+
+import SwiftUI
+import Foundation
+
+struct SettingsView: View {
+    let userDefaults = UserDefaults.standard
+
+    var body: some View {
+        VStack {
+            Spacer()
+            Button {
+                userDefaults.removeObject(forKey: UserDefaults.AUTH_TOKEN_KEY)
+            } label: {
+                Text("Log out")
+            }.buttonStyle(BlueButtonStyle())
+            
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct LogoutView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}

--- a/AirCasting/Utils/Textfield.swift
+++ b/AirCasting/Utils/Textfield.swift
@@ -14,4 +14,5 @@ func createTextfield(placeholder: String, binding: Binding<String> ) -> some Vie
         .frame(height: 50)
         .background(Color.aircastingGray.opacity(0.05))
         .border(Color.aircastingGray.opacity(0.1))
+        
 }

--- a/AirCasting/Utils/UserDefaults+Preferences.swift
+++ b/AirCasting/Utils/UserDefaults+Preferences.swift
@@ -1,0 +1,38 @@
+//
+//  UserDefaults+Preferences.swift
+//  AirCasting
+//
+//  Created by Lunar on 16/03/2021.
+//
+
+import Foundation
+
+
+extension UserDefaults {
+
+    static var AUTH_TOKEN_KEY = "auth_token"
+    
+    @UserDefault(key: AUTH_TOKEN_KEY, defaultValue: nil)
+    static var authToken: String?
+        
+}
+
+
+
+
+
+@propertyWrapper
+struct UserDefault<Value> {
+    let key: String
+    let defaultValue: Value
+    var container: UserDefaults = .standard
+
+    var wrappedValue: Value {
+        get {
+            return container.object(forKey: key) as? Value ?? defaultValue
+        }
+        set {
+            container.set(newValue, forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
**SUMMARY** 
- user can create an account,
![IMG_2570](https://user-images.githubusercontent.com/46443841/111640103-278d1d80-87fc-11eb-83c5-042505816af6.PNG)

- user can log in, 
![IMG_2569](https://user-images.githubusercontent.com/46443841/111640089-22c86980-87fc-11eb-947e-78ab90da852b.PNG)

- there's a logout button on the settings view (you can access settings using the tab bar button), it's to be rebuilt, I just needed to have log out button,
![IMG_2571](https://user-images.githubusercontent.com/46443841/111640129-2d82fe80-87fc-11eb-8de4-7ae2995a5a7b.PNG)

- there isn't any error handling if the user type the wrong password, etc, 

**Fixes for creating session:** 
- Added authorization alert for the fixed session and mobile Bluetooth. In fixed session alert should pop up when the user selects "fixed" in ChooseSessionTypeView. In mobile session, an alert pops up when the user selects Bluetooth device on SelectDeviceView. 
- If the user denies access to Bluetooth or has Bluetooth turned off, there's TurnOnBluetoothView displayed and the continue button redirects the user to either app bluetooth authorization settings or to general settings (it's impossible to direct the user to Bluetooth settings), 
NOTE: if a user is redirected to app Bluetooth authorization settings, the app automatically restets. When a user comes back, he/she has to start creating a session from the beginning. 
- If Bluetooth is authorized and  powered on, TurnOnBluetoothView shouldn't be displayed - the user should be directed to PowerABView, 
- I added a scroll view to AddNamesAndTagsView (might be a temporary solution for now being able to click the continue button because the keyboard covers it), 
- I removed pickers (indoor/outdoor and wifi/cellular) from AddNamesAndTagsView if the session is mobile. 