### PR TITLE
Speed up fetching of measurements

### DIFF
--- a/AirCasting/SessionViews/SessionCartViewModel/DefaultSyncingMeasurementsViewModel.swift
+++ b/AirCasting/SessionViews/SessionCartViewModel/DefaultSyncingMeasurementsViewModel.swift
@@ -58,9 +58,7 @@ final class DefaultSyncingMeasurementsViewModel: SyncingMeasurementsViewModel {
                                     return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
                                 }()
                                 do {
-                                    guard let streamID = streamID else {
-                                        return
-                                    }
+                                    guard let streamID = streamID else { return }
                                     try storage.addMeasurementValue(measurement.value,
                                                                     at:  location,
                                                                     toStreamWithID: streamID,


### PR DESCRIPTION
Previously we were getting streamID from database for each measurement. Now we are getting it once per stream.