### PR TITLE
AirBeam configuration - sending time in correct format

### DIFF
--- a/AirCasting/Utils/DataFormatters.swift
+++ b/AirCasting/Utils/DataFormatters.swift
@@ -35,7 +35,8 @@ enum DateFormatters {
     enum AirBeam3Configurator {
         static let usLocaleFullDateDateFormatter: DateFormatter = {
             let df = DateFormatter()
-            df.dateFormat = "dd/MM/YY-hh:mm:ss"
+            df.timeZone = TimeZone(abbreviation: "UTC")
+            df.dateFormat = "dd/MM/yy-HH:mm:ss"
             df.locale = Locale(identifier: "en_US_POSIX")
             return df
         }()


### PR DESCRIPTION
https://trello.com/c/Q90tAWd1/337-time-issues (last TODO from Graph  checklist)

There were two problems when configuring AirBeam current time (which sets AB RTC)
1. When formatting the time, we were using formatter with default timezone, which worked well for our timezone but gave 4h behind for New York. This was only visible when the session was recorded in standalone mode (as AB uses RTC only as a backup, normally takes time from the phone)
2. When formatting the time, we were using "hh" as hour format, which gave hour in 12h clock, so if session was recorded at 21, RTC would be saved to 9.
