### PR TITLE
Delay configuring AB

### DIFF
--- a/AirCasting/ABConnector/ConnectingABViewModel.swift
+++ b/AirCasting/ABConnector/ConnectingABViewModel.swift
@@ -38,12 +38,12 @@ class AirbeamConnectionViewModelDefault: AirbeamConnectionViewModel, ObservableO
             self.shouldDismissValue = !success
             
             guard success else { return }
-            self.configureABToFixed()
+            self.configureAB()
         }
     }
     
-    private func configureABToFixed() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
+    private func configureAB() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(4)) {
             if let sessionUUID = self.sessionContext.sessionUUID {
                 let configurator = AirBeam3Configurator(userAuthenticationSession: self.userAuthenticationSession,
                                                         peripheral: self.peripheral)


### PR DESCRIPTION
This should fix. the bug `“Domain: AirBeam3Configurator.swift_151 Code: 151 NSLocalizedDescription: Assertion failure: Unable to get characteristic from <CBPeripheral: 0x281bba100, identifier = 6F7CEA81-FD11-62C4-4898-2BA5200C66DA, name = AirBeam3:9c9c1f0126ac, mtu = 23, state = disconnected> file: AirBeam3Configurator.swift line: 151”` from Crashlitics. 