### PR TITLE
added delay to start recording after intteruption

### DIFF
--- a/AirCasting/MicrophoneSession/MicrophoneManager.swift
+++ b/AirCasting/MicrophoneSession/MicrophoneManager.swift
@@ -96,7 +96,7 @@ extension MicrophoneManager: AVAudioRecorderDelegate {
     func audioRecorderEndInterruption(_ recorder: AVAudioRecorder, withOptions flags: Int) {
         Log.info("audio recorder end interruption")
         if !recorder.isRecording {
-            #warning("5 second added as a "for now" implementation - find beeter way")
+            #warning("5 second added as a [for now] implementation - find beeter way")
             DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) { recorder.record() }
         }
         self.levelTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(self.timerTick), userInfo: nil, repeats: true)


### PR DESCRIPTION
https://trello.com/c/7M33g3AR/334-microphone-doesnt-resume-recording-when-other-app-was-using-a-microphone-and-then-we-came-back-to-the-app

Sometimes the beauty of work lies in the ugliness 😉

Is cannot be less than 5 sec because it won't work, it can be more of course 