### PR TITLE
Notes - manage times zones.

### DIFF
--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -311,7 +311,7 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
         let sessionEntity = try context.existingSession(uuid: sessionUUID)
         return sessionEntity.notes?.map { note -> Note in
             let n = note as! NoteEntity
-            return Note(date: n.date ?? Date(),
+            return Note(date: n.date ?? Date().currentUTCTimeZoneDate,
                                    text: n.text ?? "",
                                    lat: n.lat,
                                    long: n.long,
@@ -322,7 +322,7 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
     func fetchSpecifiedNote(for sessionUUID: SessionUUID, number: Int) throws -> Note {
         let session = try context.existingSession(uuid: sessionUUID)
         let note = (session.notes?.first(where: { ($0 as! NoteEntity).number == number }) as! NoteEntity)
-        return Note(date: note.date ?? Date(),
+        return Note(date: note.date ?? Date().currentUTCTimeZoneDate,
                     text: note.text ?? "",
                     lat: note.lat,
                     long: note.long,

--- a/AirCasting/Graph/AirCastingGraph.swift
+++ b/AirCasting/Graph/AirCastingGraph.swift
@@ -244,6 +244,6 @@ extension AirCastingGraph {
     }
     
     private func xAxisValue(for note: Note) -> Double {
-        Double(note.date.currentUTCTimeZoneDate.timeIntervalSince1970)
+        Double(note.date.timeIntervalSince1970)
     }
 }

--- a/AirCasting/Notes/NotesHandler.swift
+++ b/AirCasting/Notes/NotesHandler.swift
@@ -43,7 +43,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
         measurementStreamStorage.accessStorage { [self] storage in
             do {
                 let currentNumber = try storage.getNotes(for: sessionUUID).map(\.number).sorted(by: < ).last
-                try storage.addNote(Note(date: Date(),
+                try storage.addNote(Note(date: Date().currentUTCTimeZoneDate,
                                          text: noteText,
                                          lat: locationTracker.googleLocation.last?.location.latitude ?? 20.0,
                                          long: locationTracker.googleLocation.last?.location.longitude ?? 20.0,

--- a/AirCasting/SingleSessionSynchronizer/SessionUpdateService.swift
+++ b/AirCasting/SingleSessionSynchronizer/SessionUpdateService.swift
@@ -49,7 +49,7 @@ class DefaultSessionUpdateService: SessionUpdateService {
         
         session.notes?.forEach({ note in
             let n = note as! NoteEntity
-            notes.append(CreateSessionApi.NotesParams(date: n.date ?? Date(),
+            notes.append(CreateSessionApi.NotesParams(date: n.date ?? Date().currentUTCTimeZoneDate,
                                                       text: n.text ?? "",
                                                       lat: n.lat,
                                                       long: n.long,


### PR DESCRIPTION
For now, every not was timestamped with the current Date which could result in a time difference between graph and note. Now, every note is timestamped with Date.currentUTCTime. It matches our time zone convention now.