### PR TITLE
Fix editing

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		338C30E225F1044B00E0305C /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338C30E125F1044B00E0305C /* PersistenceController.swift */; };
 		338C30E825F10BFE00E0305C /* AirCasting.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 338C30E625F10BFE00E0305C /* AirCasting.xcdatamodeld */; };
 		3397C81F2787024C0050B333 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3397C81E2787024C0050B333 /* UserDefaults.swift */; };
+		3399394D27DA1722006144AF /* SingleSessionDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3399394C27DA1722006144AF /* SingleSessionDownloader.swift */; };
 		33AC7D5C273C1B9700EB1274 /* StandaloneSessionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AC7D5B273C1B9700EB1274 /* StandaloneSessionCardView.swift */; };
 		33BA3368266E4BCA00899343 /* MobilePeripheralSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA3367266E4BCA00899343 /* MobilePeripheralSessionManager.swift */; };
 		33BA336A266E4D1000899343 /* MobileSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA3369266E4D1000899343 /* MobileSession.swift */; };
@@ -453,6 +454,7 @@
 		338C30E725F10BFE00E0305C /* AirCasting.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AirCasting.xcdatamodel; sourceTree = "<group>"; };
 		338FE86027AAB0F1006148DA /* AirCasting v3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "AirCasting v3.xcdatamodel"; sourceTree = "<group>"; };
 		3397C81E2787024C0050B333 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
+		3399394C27DA1722006144AF /* SingleSessionDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleSessionDownloader.swift; sourceTree = "<group>"; };
 		33AC7D5B273C1B9700EB1274 /* StandaloneSessionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandaloneSessionCardView.swift; sourceTree = "<group>"; };
 		33BA3367266E4BCA00899343 /* MobilePeripheralSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePeripheralSessionManager.swift; sourceTree = "<group>"; };
 		33BA3369266E4D1000899343 /* MobileSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSession.swift; sourceTree = "<group>"; };
@@ -1300,6 +1302,7 @@
 				AC049F862608B74C00398197 /* FixedSession.swift */,
 				4FB39E392621BE7F00E5E564 /* APIClient.swift */,
 				335A8B2E2785D49100355D46 /* ShareSessionAPI.swift */,
+				3399394C27DA1722006144AF /* SingleSessionDownloader.swift */,
 			);
 			path = APICommunicator;
 			sourceTree = "<group>";
@@ -2524,6 +2527,7 @@
 				AC9F526E2652A360003CF61F /* AirSectionPickerView.swift in Sources */,
 				AC7EB37825A6FB3A00A7F2AF /* MainTabBarView.swift in Sources */,
 				B38E6CD026C5F83D00C21C45 /* StandardSesssionStopper.swift in Sources */,
+				3399394D27DA1722006144AF /* SingleSessionDownloader.swift in Sources */,
 				B30F9A612745601F00C85E17 /* SDSyncController.swift in Sources */,
 				B33B15FE27AEE6E900138FFA /* WeakRef+DisposableDataHolder.swift in Sources */,
 				750A51DA2754D47F00D6F4E7 /* GridSquare.swift in Sources */,

--- a/AirCasting/APICommunicator/SingleSessionDownloader.swift
+++ b/AirCasting/APICommunicator/SingleSessionDownloader.swift
@@ -1,0 +1,60 @@
+// Created by Lunar on 10/03/2022.
+//
+
+import Foundation
+import Resolver
+
+protocol SingleSessionDownloader {
+    func downloadSessionNameAndTags(with sessionUUID: SessionUUID, completion: @escaping (Result<SessionWithNameAndTags, Error>) -> ())
+}
+
+struct SessionWithNameAndTags: Decodable {
+    let uuid: SessionUUID
+    let title: String
+    let tagList: String
+}
+
+class DefaultSingleSessionDownloader: SingleSessionDownloader {
+    @Injected private var urlProvider: URLProvider
+    @Injected private var apiClient: APIClient
+    @Injected private var responseValidator: HTTPResponseValidator
+    @Injected private var authorisationService: RequestAuthorisationService
+    
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+    
+    func downloadSessionNameAndTags(with sessionUUID: SessionUUID, completion: @escaping (Result<SessionWithNameAndTags, Error>) -> ()) {
+        let urlComponentPart = urlProvider.baseAppURL.appendingPathComponent("api/user/sessions/update_session.json")
+        var urlComponents = URLComponents(string: urlComponentPart.absoluteString)!
+        urlComponents.queryItems = [
+            URLQueryItem(name: "uuid", value: sessionUUID.rawValue)
+        ]
+        let url = urlComponents.url!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            try authorisationService.authorise(request: &request)
+        } catch {
+            completion(.failure(error))
+        }
+
+        apiClient.requestTask(for: request) { [responseValidator, decoder] result, request in
+            switch result {
+            case .success(let response):
+                do {
+                    try responseValidator.validate(response: response.response, data: response.data)
+                    let sessionData = try decoder.decode(SessionWithNameAndTags.self, from: response.data)
+                    completion(.success(sessionData))
+                } catch {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/AirCasting/CoreData/MeasurementStreamStorage.swift
+++ b/AirCasting/CoreData/MeasurementStreamStorage.swift
@@ -262,6 +262,11 @@ final class HiddenCoreDataMeasurementStreamStorage: MeasurementStreamStorageCont
         sessionEntity.tags = tags
         try context.save()
     }
+    
+    func updateVersion(for sessionUUID: SessionUUID, to version: Int) throws {
+        let sessionEntity = try context.existingSession(uuid: sessionUUID)
+        sessionEntity.version = Int16(version)
+    }
 
     func updateSessionFollowing(_ sessionFollowing: SessionFollowing, for sessionUUID: SessionUUID) {
         do {

--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -40,38 +40,38 @@ extension NSManagedObjectContext {
     }
     
     
-    #warning("This seems odd and is also working odd. I don't think this is correct implementation")
-    // Explaination:
-    // I'm not sure why is that happening, but the fetch inside this function is returning multiple streams
-    // not associated with a single session. It causes the calling code to sometimes modify an incorrect
-    // stream object. I found this when implementing the url saving feature after uploads
-    // (https://github.com/HabitatMap/AirCastingiOS/pull/578) - I used the `Databse`s
-    // `func insertOrUpdateSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?)`
-    // to achieve session URL update and it started acting weird - adding streams to existing dB sessions
-    // etc.. I think the root of the problem is that session streams don't have a unique identifiers
-    // and we decided to use a NSManagedObjectID instead. Somehow it's not working right, but when I added
-    // additional session-id constraint it started to behave somewhat properly. But this is a blind patch
-    // and should be investigated and resolved.
-    // Issue: https://github.com/HabitatMap/AirCastingiOS/issues/579
-    
-    // Checks if stream exists, if not, creates a new one
-    func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID, for session: SessionUUID? = nil) throws -> T  {
-        let className = NSStringFromClass(T.classForCoder())
-        let fetchRequest = NSFetchRequest<T>(entityName: className)
-        fetchRequest.predicate = NSPredicate(format: "id == \(streamID)")
-        if let session = session {
-            fetchRequest.predicate = NSCompoundPredicate(type: .and,
-                                                         subpredicates: [fetchRequest.predicate!,
-                                                                         NSPredicate(format: "session.uuid == %@", session.rawValue)])
-        }
-        
-        let results = try self.fetch(fetchRequest)
-        if let existing  = results.first { return existing }
-        
-        let new: T = T(context: self)
-        new.setValue(streamID, forKey: "id")
-        return new
-    }
+//    #warning("This seems odd and is also working odd. I don't think this is correct implementation")
+//    // Explaination:
+//    // I'm not sure why is that happening, but the fetch inside this function is returning multiple streams
+//    // not associated with a single session. It causes the calling code to sometimes modify an incorrect
+//    // stream object. I found this when implementing the url saving feature after uploads
+//    // (https://github.com/HabitatMap/AirCastingiOS/pull/578) - I used the `Databse`s
+//    // `func insertOrUpdateSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?)`
+//    // to achieve session URL update and it started acting weird - adding streams to existing dB sessions
+//    // etc.. I think the root of the problem is that session streams don't have a unique identifiers
+//    // and we decided to use a NSManagedObjectID instead. Somehow it's not working right, but when I added
+//    // additional session-id constraint it started to behave somewhat properly. But this is a blind patch
+//    // and should be investigated and resolved.
+//    // Issue: https://github.com/HabitatMap/AirCastingiOS/issues/579
+//    
+//    // Checks if stream exists, if not, creates a new one
+//    func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID, for session: SessionUUID? = nil) throws -> T  {
+//        let className = NSStringFromClass(T.classForCoder())
+//        let fetchRequest = NSFetchRequest<T>(entityName: className)
+//        fetchRequest.predicate = NSPredicate(format: "id == \(streamID)")
+//        if let session = session {
+//            fetchRequest.predicate = NSCompoundPredicate(type: .and,
+//                                                         subpredicates: [fetchRequest.predicate!,
+//                                                                         NSPredicate(format: "session.uuid == %@", session.rawValue)])
+//        }
+//        
+//        let results = try self.fetch(fetchRequest)
+//        if let existing  = results.first { return existing }
+//        
+//        let new: T = T(context: self)
+//        new.setValue(streamID, forKey: "id")
+//        return new
+//    }
     
     func newOrExisting<T: NSManagedObject>(uuid: SessionUUID) throws -> T  {
         let className = NSStringFromClass(T.classForCoder())

--- a/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
+++ b/AirCasting/CoreData/NSManagedObjectContext+Utils.swift
@@ -39,40 +39,6 @@ extension NSManagedObjectContext {
         return new
     }
     
-    
-//    #warning("This seems odd and is also working odd. I don't think this is correct implementation")
-//    // Explaination:
-//    // I'm not sure why is that happening, but the fetch inside this function is returning multiple streams
-//    // not associated with a single session. It causes the calling code to sometimes modify an incorrect
-//    // stream object. I found this when implementing the url saving feature after uploads
-//    // (https://github.com/HabitatMap/AirCastingiOS/pull/578) - I used the `Databse`s
-//    // `func insertOrUpdateSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?)`
-//    // to achieve session URL update and it started acting weird - adding streams to existing dB sessions
-//    // etc.. I think the root of the problem is that session streams don't have a unique identifiers
-//    // and we decided to use a NSManagedObjectID instead. Somehow it's not working right, but when I added
-//    // additional session-id constraint it started to behave somewhat properly. But this is a blind patch
-//    // and should be investigated and resolved.
-//    // Issue: https://github.com/HabitatMap/AirCastingiOS/issues/579
-//    
-//    // Checks if stream exists, if not, creates a new one
-//    func newOrExisting<T: NSManagedObject>(streamID: MeasurementStreamID, for session: SessionUUID? = nil) throws -> T  {
-//        let className = NSStringFromClass(T.classForCoder())
-//        let fetchRequest = NSFetchRequest<T>(entityName: className)
-//        fetchRequest.predicate = NSPredicate(format: "id == \(streamID)")
-//        if let session = session {
-//            fetchRequest.predicate = NSCompoundPredicate(type: .and,
-//                                                         subpredicates: [fetchRequest.predicate!,
-//                                                                         NSPredicate(format: "session.uuid == %@", session.rawValue)])
-//        }
-//        
-//        let results = try self.fetch(fetchRequest)
-//        if let existing  = results.first { return existing }
-//        
-//        let new: T = T(context: self)
-//        new.setValue(streamID, forKey: "id")
-//        return new
-//    }
-    
     func newOrExisting<T: NSManagedObject>(uuid: SessionUUID) throws -> T  {
         let className = NSStringFromClass(T.classForCoder())
         let fetchRequest = NSFetchRequest<T>(entityName: className)
@@ -88,7 +54,6 @@ extension NSManagedObjectContext {
         return new
     }
 }
-
 
 extension NSManagedObjectContext {
 

--- a/AirCasting/CoreData/PersistenceController+Database.swift
+++ b/AirCasting/CoreData/PersistenceController+Database.swift
@@ -25,12 +25,11 @@ extension PersistenceController: SessionsFetchable {
 }
 
 extension PersistenceController: SessionInsertable {
-    func insertOrUpdateSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?) {
+    func insertSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?) {
         let context = self.editContext
         context.perform {
-            do {
-                try sessions.forEach {
-                    let sessionEntity: SessionEntity = try context.newOrExisting(uuid: $0.uuid)
+            sessions.forEach {
+                    let sessionEntity: SessionEntity = SessionEntity(context: context)
                     sessionEntity.uuid = $0.uuid
                     sessionEntity.type = $0.type
                     sessionEntity.name = $0.name
@@ -56,13 +55,8 @@ extension PersistenceController: SessionInsertable {
                         noteEntity.number = Int64($0.number)
                         noteEntity.session = sessionEntity
                     }
-                    try $0.measurementStreams?.forEach {
-                        let streamEntity: MeasurementStreamEntity
-                        if let id = $0.id {
-                            streamEntity = try context.newOrExisting(streamID: id, for: sessionEntity.uuid)
-                        } else {
-                            streamEntity = MeasurementStreamEntity(context: context)
-                        }
+                    $0.measurementStreams?.forEach {
+                        let streamEntity = MeasurementStreamEntity(context: context)
                         streamEntity.id = $0.id
                         streamEntity.measurementShortType = $0.measurementShortType
                         streamEntity.measurementType = $0.measurementType
@@ -79,6 +73,7 @@ extension PersistenceController: SessionInsertable {
                         streamEntity.session = sessionEntity
                     }
                 }
+            do {
                 try context.save()
                 completion?(nil)
             } catch {

--- a/AirCasting/Notes/NotesHandler.swift
+++ b/AirCasting/Notes/NotesHandler.swift
@@ -64,9 +64,15 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
             do {
                 try storage.deleteNote(note, for: sessionUUID)
                 fetchSession { session in
-                    self.sessionUpdateService.updateSession(session: session) { _ in
-                        Log.info("Notes successfully updated")
-                        completion()
+                    self.sessionUpdateService.updateSession(session: session) { result in
+                        switch result {
+                        case .success(let updateData):
+                            try? storage.updateVersion(for: sessionUUID, to: updateData.version)
+                            Log.info("Notes successfully updated")
+                            completion()
+                        case .failure(let error):
+                            Log.info("Failed updating session while updating notes: \(error.localizedDescription)")
+                        }
                     }
                 }
             } catch {
@@ -80,9 +86,15 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
             do {
                 try storage.updateNote(note, newText: newText, for: sessionUUID)
                 fetchSession { session in
-                    self.sessionUpdateService.updateSession(session: session) { _ in
-                        Log.info("Notes successfully updated")
-                        completion()
+                    self.sessionUpdateService.updateSession(session: session) { result in
+                        switch result {
+                        case .success(let updateData):
+                            try? storage.updateVersion(for: sessionUUID, to: updateData.version)
+                            Log.info("Notes successfully updated")
+                            completion()
+                        case .failure(let error):
+                            Log.info("Failed updating session while updating notes: \(error.localizedDescription)")
+                        }
                     }
                 }
             } catch {

--- a/AirCasting/Notes/NotesHandler.swift
+++ b/AirCasting/Notes/NotesHandler.swift
@@ -64,7 +64,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
             do {
                 try storage.deleteNote(note, for: sessionUUID)
                 fetchSession { session in
-                    self.sessionUpdateService.updateSession(session: session) {
+                    self.sessionUpdateService.updateSession(session: session) { _ in
                         Log.info("Notes successfully updated")
                         completion()
                     }
@@ -80,7 +80,7 @@ class NotesHandlerDefault: NSObject, NotesHandler, NSFetchedResultsControllerDel
             do {
                 try storage.updateNote(note, newText: newText, for: sessionUUID)
                 fetchSession { session in
-                    self.sessionUpdateService.updateSession(session: session) {
+                    self.sessionUpdateService.updateSession(session: session) { _ in
                         Log.info("Notes successfully updated")
                         completion()
                     }

--- a/AirCasting/SessionViews/EditView.swift
+++ b/AirCasting/SessionViews/EditView.swift
@@ -24,6 +24,10 @@ struct EditView<VM: EditViewModel>: View {
         .onAppear {
             editSessionViewModel.downloadSessionAndReloadView()
         }
+        .onChange(of: editSessionViewModel.shouldDismiss) {
+            $0 ? presentationMode.wrappedValue.dismiss() : ()
+        }
+        .alert(item: $editSessionViewModel.alert, content: { $0.makeAlert() })
     }
     
     var editView: some View {
@@ -66,9 +70,6 @@ struct EditView<VM: EditViewModel>: View {
         })
             .buttonStyle(BlueButtonStyle())
             .padding(.top, 20)
-            .onChange(of: editSessionViewModel.didSave) {
-                $0 ? presentationMode.wrappedValue.dismiss() : ()
-            }
     }
     
     private var cancelButton: some View {

--- a/AirCasting/SessionViews/EditViewModel.swift
+++ b/AirCasting/SessionViews/EditViewModel.swift
@@ -10,23 +10,23 @@ protocol EditViewModel: ObservableObject {
     var sessionName: String { get set }
     var sessionTags: String { get set }
     var isSessionDownloaded: Bool { get set }
+    var alert: AlertInfo? { get set }
     var shouldShowError: Bool { get }
-    var didSave: Bool { get }
+    var shouldDismiss: Bool { get }
     
     func saveChanges()
     func downloadSessionAndReloadView()
-    func reload()
 }
 
 class EditSessionViewModel: EditViewModel {
-    
     @Published var isSessionDownloaded = false
     @Published var sessionName = ""
     @Published var sessionTags = ""
     @Published var shouldShowError = false
-    @Published var didSave = false
+    @Published var shouldDismiss = false
+    @Published var alert: AlertInfo?
     @Injected private var measurementStreamStorage: MeasurementStreamStorage
-    @Injected private var sessionSynchronizer: SingleSessionSynchronizer
+    @Injected private var sessionDownloader: SingleSessionDownloader
     @Injected private var sessionUpdateService: SessionUpdateService
     private let sessionUUID: SessionUUID
     
@@ -47,9 +47,21 @@ class EditSessionViewModel: EditViewModel {
                                                      tags: tags,
                                                      for: sessionUUID)
                 let session = try storage.getExistingSession(with: sessionUUID)
-                sessionUpdateService.updateSession(session: session) {
+                sessionUpdateService.updateSession(session: session) { result in
+                    switch result {
+                    case .success(let session):
+                        do {
+                            try storage.updateVersion(for: sessionUUID,to: session.version)
+                        } catch {
+                            Log.info("Error while saving edited session name and tags \(error).")
+                            showAlert(InAppAlerts.failedSavingData(dismiss: self.dismissView()))
+                        }
+                    case .failure(let error):
+                        Log.info("Error while sending updated session to backend \(error).")
+                        showAlert(InAppAlerts.failedSavingData(dismiss: self.dismissView()))
+                    }
                     DispatchQueue.main.async {
-                        didSave = true
+                        shouldDismiss = true
                     }
                 }
             } catch {
@@ -59,27 +71,47 @@ class EditSessionViewModel: EditViewModel {
     }
     
     func downloadSessionAndReloadView() {
-        sessionSynchronizer.downloadSingleSession(sessionUUID: sessionUUID) {
-            DispatchQueue.main.async {  
-                self.isSessionDownloaded = true
-                self.reload()
+        sessionDownloader.downloadSessionNameAndTags(with: sessionUUID) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let sessionData):
+                self.updateSessionNameAndTagsWithBackendData(name: sessionData.title, tags: sessionData.tagList) {
+                    DispatchQueue.main.async {
+                        self.sessionName = sessionData.title
+                        self.sessionTags = sessionData.tagList
+                        self.isSessionDownloaded = true
+                    }
+                }
+            case .failure(let error):
+                Log.error("Error downloading session data for edit view: \(error.localizedDescription)")
+                self.showAlert(InAppAlerts.failedToDownload(dismiss: self.dismissView()))
             }
         }
     }
     
-    internal func reload() {
-        measurementStreamStorage.accessStorage { [self] storage in
+    private func updateSessionNameAndTagsWithBackendData(name: String, tags: String, closure: @escaping () -> ()) {
+        self.measurementStreamStorage.accessStorage { [self] storage in
             do {
-                let session = try storage.getExistingSession(with: sessionUUID)
-                guard let name = session.name else { return }
-                let tags = session.tags ?? ""
-                DispatchQueue.main.async {
-                    sessionName = name
-                    sessionTags = tags
-                }
+                try storage.updateSessionNameAndTags(name: name,
+                                                     tags: tags,
+                                                     for: self.sessionUUID)
+                closure()
             } catch {
-                Log.error("Error reloading session data for edit view.")
+                Log.error("Failed to save new session name and tags")
+                showAlert(InAppAlerts.failedSavingData(dismiss: self.dismissView()))
             }
+        }
+    }
+    
+    private func showAlert(_ alert: AlertInfo) {
+        DispatchQueue.main.async {
+            self.alert = alert
+        }
+    }
+    
+    private func dismissView() {
+        DispatchQueue.main.async {
+            self.shouldDismiss = true
         }
     }
 }

--- a/AirCasting/SessionViews/SessionCartViewModel/DefaultDeleteSessionViewModel.swift
+++ b/AirCasting/SessionViews/SessionCartViewModel/DefaultDeleteSessionViewModel.swift
@@ -96,7 +96,7 @@ class DefaultDeleteSessionViewModel: DeleteSessionViewModel {
     private func processStreamDeleting() {
         self.measurementStreamStorage.accessStorage { [self] storage in
             guard let sessionToPass = try? storage.getExistingSession(with: session.uuid) else { return }
-            streamRemover.updateSession(session: sessionToPass) {
+            streamRemover.updateSession(session: sessionToPass) { _ in
                 try? storage.deleteStreams(session.uuid)
             }
         }

--- a/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
@@ -40,7 +40,7 @@ final class SessionSynchronizationDatabase: SessionSynchronizationStore {
     func addSessions(with sessionsData: [SessionsSynchronization.SessionStoreSessionData]) -> Future<Void, Error> {
         return .init { [sessionsInserter] promise in
             sessionsInserter
-                .insertOrUpdateSessions(sessionsData.map { sessionData in
+                .insertSessions(sessionsData.map { sessionData in
                     let streams = sessionData.measurementStreams.map {
                         Database.MeasurementStream(id: MeasurementStreamID($0.id),
                                                    sensorName: $0.sensorName,

--- a/AirCasting/SessionsSynchronization/Controller/SessionSynchronizationController.swift
+++ b/AirCasting/SessionsSynchronization/Controller/SessionSynchronizationController.swift
@@ -52,15 +52,6 @@ final class SessionSynchronizationController: SessionSynchronizer {
         cancellables = []
     }
     
-    // MARK: - SingleSessionSynchronizer
-    func downloadSingleSession(sessionUUID: SessionUUID, completion: @escaping () -> Void) {
-        processDownloads(context: .init(needToBeDownloaded: [sessionUUID], needToBeUploaded: [], removed: []))
-            .sink { _ in
-                completion()
-            } receiveValue: { _ in }
-            .store(in: &cancellables)
-    }
-    
     // MARK: - Private
     
     private func translateError(streamError: Error) -> SessionSynchronizerError {

--- a/AirCasting/SessionsSynchronization/Controller/SessionSynchronizer.swift
+++ b/AirCasting/SessionsSynchronization/Controller/SessionSynchronizer.swift
@@ -16,7 +16,7 @@ struct SessionSynchronizationOptions: OptionSet {
 }
 
 /// Defines the interface for objects that provide session list synchronization to the app
-protocol SessionSynchronizer: SingleSessionSynchronizer {
+protocol SessionSynchronizer {
     var syncInProgress: CurrentValueSubject<Bool, Never> { get }
     /// Triggers a new synchronization pass
     /// - Parameter completion: closure called when sycnhronization finishes
@@ -25,11 +25,6 @@ protocol SessionSynchronizer: SingleSessionSynchronizer {
     func stopSynchronization()
     /// A plugin point for anyone interested in generated errors
     var errorStream: SessionSynchronizerErrorStream? { get set }
-}
-
-protocol SingleSessionSynchronizer {
-    /// Triggers downloading single session
-    func downloadSingleSession(sessionUUID: SessionUUID, completion: @escaping () -> Void)
 }
 
 extension SessionSynchronizer {
@@ -57,7 +52,5 @@ struct DummySessionSynchronizer: SessionSynchronizer {
     var errorStream: SessionSynchronizerErrorStream?
     func triggerSynchronization(options streamOptions: SessionSynchronizationOptions, completion: (() -> Void)?) { completion?() }
     func stopSynchronization() { }
-    func downloadSingleSession(sessionUUID: SessionUUID, completion: () -> Void) {
-        completion() }
 }
 #endif

--- a/AirCasting/SessionsSynchronization/Controller/Utils/ScheduledSessionSynchronizerProxy.swift
+++ b/AirCasting/SessionsSynchronization/Controller/Utils/ScheduledSessionSynchronizerProxy.swift
@@ -56,14 +56,4 @@ final class ScheduledSessionSynchronizerProxy<S: Scheduler>: SessionSynchronizer
             self?.controller.stopSynchronization()
         }
     }
-    
-    // MARK: - SingleSessionSynchronizer
-    
-    func downloadSingleSession(sessionUUID: SessionUUID, completion: @escaping () -> Void) {
-        scheduler.schedule { [weak self] in
-            guard let self = self else { return }
-            self.controller.downloadSingleSession(sessionUUID: sessionUUID,
-                                               completion: completion)
-        }
-    }
 }

--- a/AirCasting/SessionsSynchronization/Database/Database.swift
+++ b/AirCasting/SessionsSynchronization/Database/Database.swift
@@ -23,7 +23,7 @@ protocol SessionRemovable {
 }
 
 protocol SessionInsertable {
-    func insertOrUpdateSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?)
+    func insertSessions(_ sessions: [Database.Session], completion: ((Error?) -> Void)?)
 }
 
 protocol SessionUpdateable {

--- a/AirCasting/Utils/InAppAlerts.swift
+++ b/AirCasting/Utils/InAppAlerts.swift
@@ -135,6 +135,24 @@ struct InAppAlerts {
                              action: nil)
                   ])
     }
+    
+    static func failedToDownload(dismiss: ()) -> AlertInfo {
+        AlertInfo(title: Strings.InAppAlerts.failedDownloadTitle,
+                  message: Strings.InAppAlerts.failedDownloadMessage,
+                  buttons: [
+                    .default(title: Strings.InAppAlerts.failedDownloadButton,
+                             action: { dismiss })
+                  ])
+    }
+    
+    static func failedSavingData(dismiss: ()) -> AlertInfo {
+        AlertInfo(title: Strings.InAppAlerts.failedSavingTitle,
+                  message: Strings.InAppAlerts.failedSavingMessage,
+                  buttons: [
+                    .default(title: Strings.InAppAlerts.failedSavingButton,
+                             action: { dismiss })
+                  ])
+    }
 }
 
 import SwiftUI

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -862,6 +862,18 @@ struct Strings {
                                                                      comment: "")
         static let unableToLogOutButton: String = NSLocalizedString("Got it!",
                                                                     comment: "")
+        static let failedDownloadTitle: String = NSLocalizedString("Connection failure",
+                                                                   comment: "")
+        static let failedDownloadMessage: String = NSLocalizedString("Something went wrong when downloading most recent session data. Please try again later.",
+                                                                     comment: "")
+        static let failedDownloadButton: String = NSLocalizedString("Got it!",
+                                                                    comment: "")
+        static let failedSavingTitle: String = NSLocalizedString("Request failed",
+                                                                   comment: "")
+        static let failedSavingMessage: String = NSLocalizedString("New data couldn't be saved. Please try again later.",
+                                                                     comment: "")
+        static let failedSavingButton: String = NSLocalizedString("Got it!",
+                                                                    comment: "")
     }
     
     enum AddNoteView {

--- a/AppDelegate+Injection.swift
+++ b/AppDelegate+Injection.swift
@@ -85,6 +85,7 @@ extension Resolver: ResolverRegistering {
         main.register { DefaultHTTPResponseValidator() as HTTPResponseValidator }
         main.register { UserDefaultsURLProvider() as URLProvider }
         main.register { DefaultNetworkChecker() as NetworkChecker }.scope(.application)
+        main.register { DefaultSingleSessionDownloader() as SingleSessionDownloader }
         
         // MARK: - Feature flags
         main.register { DefaultRemoteNotificationRouter() }
@@ -127,7 +128,6 @@ extension Resolver: ResolverRegistering {
         main.register {
             ScheduledSessionSynchronizerProxy(controller: SessionSynchronizationController(), scheduler: DispatchQueue.global())
         }.scope(.application)
-            .implements(SingleSessionSynchronizer.self)
             .implements(SessionSynchronizer.self)
         
         // MARK: - Location handling


### PR DESCRIPTION
## Description
This PR fixed bug with duplicated streams after editing.
Turns out there were two underlying issues:
* When the user entered the editing screen, the app performed sync with backend just for this one session to download its most recent data from backend (the goal was to have the newest version of the name and tags). However, while saving this session data, the app was also saving the streams from backend and streams got duplicated because they had different id locally (0) and in backend database (some number assigned on backend). Now, we are not saving all of the session data, just its name and tags, and this eliminated the stream duplication at this stage of the edit, but in the future, the underlying problem should also be fixed, i.e. we should save stream id from backend locally.
* When we were sending the updated name ang tags to backend, backend bumped session's version by 1. We didn't save this new version number locally. Then, when the app performed sync, there was discrepancy between the local version number for the session and the version number on backend, and because of that, the session was downloaded again, and the streams were duplicated (because of the id mismatch). Now, we are saving the new version number after updating session data to backend, and this eliminated this issue (but still, we should really get the right ids for streams).

## Code changes
* Rewriting logic in editViewModel
* Adding handling of response in sessionUpdateService
* Removing single session synchroniser
* Changing back insertOrUpdateSessions to insertSessions

https://trello.com/c/NgCUPYg4
