### PR TITLE
Sd sync fixed sessions upload refactor

### DIFF
--- a/AirCasting/ABConnector/SDSyncController.swift
+++ b/AirCasting/ABConnector/SDSyncController.swift
@@ -132,6 +132,7 @@ class SDSyncController {
     }
     
     private func process(mobileSessionFile: URL, deviceID: String, completion: @escaping (Bool) -> Void) {
+        Log.info("Processing fixed file")
         self.mobileSessionsSaver.saveDataToDb(fileURL: mobileSessionFile, deviceID: deviceID) { result in
             switch result {
             case .success(let sessions):

--- a/AirCasting/SDSync/FixedSessions/SDCardFixedSessionsSavingService.swift
+++ b/AirCasting/SDSync/FixedSessions/SDCardFixedSessionsSavingService.swift
@@ -49,7 +49,6 @@ class SDCardFixedSessionsUploadingService {
                         
                         guard self.processAndSync(streamsWithMeasurements: streamsWithMeasurements, deviceID: deviceID) else {
                             Log.error("Upload fixed sessions stream failed")
-                            completion(.failure(UploadingError.uploadError))
                             uploadFailed = true
                             return
                         }
@@ -59,6 +58,11 @@ class SDCardFixedSessionsUploadingService {
                         Log.info("Reached end of csv file")
                     }
                 })
+                guard !uploadFailed else {
+                    completion(.failure(UploadingError.uploadError))
+                    return
+                }
+                
                 guard self.processAndSync(streamsWithMeasurements: streamsWithMeasurements, deviceID: deviceID) else {
                     completion(.failure(UploadingError.uploadError))
                     return


### PR DESCRIPTION
Previously we were reading the whole file content to memory before sending streams to backend. Now we are introducing a buffer mechanism and sending measurements in 50 elements chunks.