### PR TITLE
Fix graph crash

### DIFF
--- a/AirCasting/Graph/AirCastingGraph.swift
+++ b/AirCasting/Graph/AirCastingGraph.swift
@@ -219,9 +219,13 @@ extension AirCastingGraph {
     }
     
     private func visibleRangeForXAxis(with dataSet: IChartDataSet) -> ClosedRange<Double> {
-        lineChartView.lowestVisibleX < lineChartView.highestVisibleX ?
-            { lineChartView.lowestVisibleX...lineChartView.highestVisibleX }() :
-            { dataSet.xMin...dataSet.xMax }()
+        if lineChartView.lowestVisibleX < lineChartView.highestVisibleX {
+            return { lineChartView.lowestVisibleX...lineChartView.highestVisibleX }()
+        } else if dataSet.xMin <= dataSet.xMax {
+            return { dataSet.xMin...dataSet.xMax }()
+        } else {
+            return { dataSet.xMax...dataSet.xMin }()
+        }
     }
     
     private func onScreenButtons(dataSet: IChartDataSet) -> [NoteButtonData] {


### PR DESCRIPTION
https://trello.com/c/wgIRhQzp

This PR fixes the crash that was appearing from time to time on firebase. Looking at the crash report it looks like the crash was caused when a closed range was created and it looks like swift is throwing a fatal error when upperBound < lowerBound.
I don't know why xMax would be smaller than xMin, but I hope this solution will prevent this crash from happening.