### PR TITLE
Button lower and background on S&F cards

### DIFF
--- a/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
@@ -41,13 +41,7 @@ struct BottomCardView: View {
             viewModel.setIsModalScreenPresented(using: value)
         }), content: { viewModel.initCompleteScreen() })
         .frame(width: 200, alignment: .leading)
-        .padding([.all], 10)
-        .background(
-            Group {
-                Color.white
-                    .cardShadow()
-            }
-        )
+        .padding(10)
         .cornerRadius(8)
     }
 }

--- a/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
@@ -178,7 +178,7 @@ private extension SearchMapView {
                                 Group {
                                     Color.white
                                         .cornerRadius(8)
-                                        .cardShadow()
+                                        .shadow(color: .sessionCardShadow, radius: 1, x: 0, y: 2)
                                 }
                             )
                             .overlay(

--- a/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
@@ -43,6 +43,7 @@ struct SearchMapView: View {
                         Spacer()
                         sensorTypeText
                     }
+                    .padding(.bottom, 10)
                     searchAgainButton
                         .foregroundColor(.white)
                         .frame(width: reader.size.width / 2.2, height: 8, alignment: .center)
@@ -173,6 +174,13 @@ private extension SearchMapView {
                             .onMarkerChange(action: { pointer in
                                 viewModel.markerSelectionChanged(using: pointer)
                             })
+                            .background(
+                                Group {
+                                    Color.white
+                                        .cornerRadius(8)
+                                        .cardShadow()
+                                }
+                            )
                             .overlay(
                                 RoundedRectangle(cornerRadius: 8)
                                     .stroke(viewModel.strokeColor(with: session.id), lineWidth: 1)


### PR DESCRIPTION
Button responsible for redoing search moved 10px lower then it was.
CardShadow applied to session card on the S&F map.

https://trello.com/c/UuSD1yhI/715-background-of-sessions-and-button-lower