### PR TITLE
Alternative reordering button fix - coreDataHook refactor

### DIFF
--- a/AirCasting/CoreData/CoreDataHook.swift
+++ b/AirCasting/CoreData/CoreDataHook.swift
@@ -6,6 +6,7 @@ import CoreData
 
 final class CoreDataHook: NSObject, ObservableObject {
     @Published private(set) var sessions: [Sessionable] = []
+    @Published private(set) var sessionsCount = 0
     private var selectedSection: DashboardSection?
     private var observerToken: AnyObject?
 
@@ -80,7 +81,7 @@ final class CoreDataHook: NSObject, ObservableObject {
         refreshSessions()
     }
 
-    func refreshSessions() {
+    private func refreshSessions() {
         let sessionEntities = fetchedResultsController.fetchedObjects ?? []
         let externalSessionEntities = externalSessionsFetchedResultsController.fetchedObjects ?? []
         sessions = sessionEntities + externalSessionEntities
@@ -88,6 +89,7 @@ final class CoreDataHook: NSObject, ObservableObject {
         sessions = sessions.sorted {
             ($0.userInterface?.rowOrder ?? 0) > ($1.userInterface?.rowOrder ?? 0)
         }
+        sessionsCount = sessions.count
     }
 }
 

--- a/AirCasting/CoreData/CoreDataHook.swift
+++ b/AirCasting/CoreData/CoreDataHook.swift
@@ -94,8 +94,15 @@ final class CoreDataHook: NSObject, ObservableObject {
 }
 
 extension CoreDataHook: NSFetchedResultsControllerDelegate {
-
-    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        refreshSessions()
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        guard anObject is Sessionable else { return }
+        
+        switch type {
+        case .insert:
+            refreshSessions()
+        case .delete:
+            refreshSessions()
+        default: break
+        }
     }
 }

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -12,7 +12,7 @@ import Combine
 import Resolver
 
 struct DashboardView: View {
-    @StateObject var coreDataHook: CoreDataHook
+//    @StateObject var coreDataHook: CoreDataHook
     @FetchRequest<SensorThreshold>(sortDescriptors: [.init(key: "sensorName", ascending: true)]) var thresholds
     @EnvironmentObject var selectedSection: SelectedSection
     @EnvironmentObject var reorderButton: ReorderButton
@@ -24,14 +24,14 @@ struct DashboardView: View {
     @Injected private var sessionSynchronizer: SessionSynchronizer
     @Injected private var persistenceController: PersistenceController
 
-    private var sessions: [Sessionable] {
-        coreDataHook.sessions
-    }
+//    private var sessions: [Sessionable] {
+//        coreDataHook.sessions
+//    }
 
-    init(coreDataHook: CoreDataHook) {
+    init() {
         let navBarAppearance = UINavigationBar.appearance()
         navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.darkBlue)]
-        _coreDataHook = StateObject(wrappedValue: coreDataHook)
+//        _coreDataHook = StateObject(wrappedValue: coreDataHook)
     }
 
     var body: some View {
@@ -40,8 +40,7 @@ struct DashboardView: View {
                 .alert(item: $alert, content: { $0.makeAlert() })
             if reorderButton.reorderIsOn {
                 followingReorderTab
-                ReorderingDashboard(sessions: sessions,
-                                    thresholds: Array(self.thresholds))
+                ReorderingDashboard(thresholds: Array(self.thresholds), context: persistenceController.viewContext)
             } else {
                 sessionTypePicker
                 TabView(selection: $selectedSection.section) {
@@ -78,11 +77,17 @@ struct DashboardView: View {
             sessionSynchronizer.triggerSynchronization() { isRefreshing = false }
         })
         .onAppear() {
-            try! coreDataHook.setup(selectedSection: self.selectedSection.section)
+            Log.info("APPEARED")
         }
-        .onChange(of: selectedSection.section) { newValue in
-            try! coreDataHook.setup(selectedSection: newValue)
+        .onDisappear() {
+            Log.info("DISAPPEARED")
         }
+//        .onAppear() {
+//            try! coreDataHook.setup(selectedSection: self.selectedSection.section)
+//        }
+//        .onChange(of: selectedSection.section) { newValue in
+//            try! coreDataHook.setup(selectedSection: newValue)
+//        }
     }
     
     private var customNavigationBar: some View {

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -80,6 +80,9 @@ struct DashboardView: View {
         .onAppear() {
             try! coreDataHook.setup(selectedSection: self.selectedSection.section)
         }
+        .onChange(of: selectedSection.section) { newValue in
+            try! coreDataHook.setup(selectedSection: newValue)
+        }
     }
     
     private var customNavigationBar: some View {

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -12,7 +12,6 @@ import Combine
 import Resolver
 
 struct DashboardView: View {
-//    @StateObject var coreDataHook: CoreDataHook
     @FetchRequest<SensorThreshold>(sortDescriptors: [.init(key: "sensorName", ascending: true)]) var thresholds
     @EnvironmentObject var selectedSection: SelectedSection
     @EnvironmentObject var reorderButton: ReorderButton
@@ -24,14 +23,9 @@ struct DashboardView: View {
     @Injected private var sessionSynchronizer: SessionSynchronizer
     @Injected private var persistenceController: PersistenceController
 
-//    private var sessions: [Sessionable] {
-//        coreDataHook.sessions
-//    }
-
     init() {
         let navBarAppearance = UINavigationBar.appearance()
         navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.darkBlue)]
-//        _coreDataHook = StateObject(wrappedValue: coreDataHook)
     }
 
     var body: some View {
@@ -40,7 +34,7 @@ struct DashboardView: View {
                 .alert(item: $alert, content: { $0.makeAlert() })
             if reorderButton.reorderIsOn {
                 followingReorderTab
-                ReorderingDashboard(thresholds: Array(self.thresholds), context: persistenceController.viewContext)
+                ReorderingDashboard(thresholds: Array(self.thresholds))
             } else {
                 sessionTypePicker
                 TabView(selection: $selectedSection.section) {

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -70,18 +70,6 @@ struct DashboardView: View {
             }
             sessionSynchronizer.triggerSynchronization() { isRefreshing = false }
         })
-        .onAppear() {
-            Log.info("APPEARED")
-        }
-        .onDisappear() {
-            Log.info("DISAPPEARED")
-        }
-//        .onAppear() {
-//            try! coreDataHook.setup(selectedSection: self.selectedSection.section)
-//        }
-//        .onChange(of: selectedSection.section) { newValue in
-//            try! coreDataHook.setup(selectedSection: newValue)
-//        }
     }
     
     private var customNavigationBar: some View {

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -10,8 +10,8 @@ struct ReorderingDashboard: View {
     @EnvironmentObject var searchAndFollowButton: SearchAndFollowButton
     @State private var changedView: Bool = false
     
-    init(thresholds: [SensorThreshold], context: NSManagedObjectContext) {
-        _viewModel = .init(wrappedValue: ReorderingDashboardViewModel(thresholds: thresholds, context: context))
+    init(thresholds: [SensorThreshold]) {
+        _viewModel = .init(wrappedValue: ReorderingDashboardViewModel(thresholds: thresholds))
     }
     
     private let columns = [GridItem(.flexible())]
@@ -54,7 +54,7 @@ struct ReorderingDashboard: View {
 #if DEBUG
 struct ReorderingDashboard_Previews: PreviewProvider {
     static var previews: some View {
-        ReorderingDashboard(sessions: [SessionEntity.mock(uuid: "mock1"), SessionEntity.mock(uuid: "mock2"), SessionEntity.mock(uuid: "mock3")], thresholds: [.mock, .mock])
+        ReorderingDashboard(thresholds: [.mock, .mock])
             .environmentObject(SearchAndFollowButton())
     }
 }

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -18,21 +18,19 @@ struct ReorderingDashboard: View {
     
     var body: some View {
         ScrollView {
-            LoadingView(isShowing: $viewModel.isLoading) {
-                LazyVGrid(columns: columns) {
-                    ForEach(viewModel.sessions, id: \.uuid) { session in
-                        ReoredringSessionCard(session: session, thresholds: viewModel.thresholds)
-                            .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.white.opacity(0.8) : Color.clear)
-                            .onDrag({
-                                viewModel.currentlyDraggedSession = session
-                                changedView = false
-                                return NSItemProvider(object: String(describing: session.uuid) as NSString)
-                            })
-                            .onDrop(of: [.text], delegate: DropViewDelegate(sessionAtDropDestination: session, currentlyDraggedSession: $viewModel.currentlyDraggedSession, sessions: $viewModel.sessions, changedView: $changedView))
-                    }
+            LazyVGrid(columns: columns) {
+                ForEach(viewModel.sessions, id: \.uuid) { session in
+                    ReoredringSessionCard(session: session, thresholds: viewModel.thresholds)
+                        .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.white.opacity(0.8) : Color.clear)
+                        .onDrag({
+                            viewModel.currentlyDraggedSession = session
+                            changedView = false
+                            return NSItemProvider(object: String(describing: session.uuid) as NSString)
+                        })
+                        .onDrop(of: [.text], delegate: DropViewDelegate(sessionAtDropDestination: session, currentlyDraggedSession: $viewModel.currentlyDraggedSession, sessions: $viewModel.sessions, changedView: $changedView))
                 }
-                .padding()
             }
+            .padding()
         }
         .onAppear(perform: {
             searchAndFollowButton.isHidden = true

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -2,6 +2,7 @@
 //
 
 import SwiftUI
+import CoreData
 
 struct ReorderingDashboard: View {
     
@@ -9,27 +10,29 @@ struct ReorderingDashboard: View {
     @EnvironmentObject var searchAndFollowButton: SearchAndFollowButton
     @State private var changedView: Bool = false
     
-    init(sessions: [Sessionable], thresholds: [SensorThreshold]) {
-        _viewModel = .init(wrappedValue: ReorderingDashboardViewModel(sessions: sessions, thresholds: thresholds))
+    init(thresholds: [SensorThreshold], context: NSManagedObjectContext) {
+        _viewModel = .init(wrappedValue: ReorderingDashboardViewModel(thresholds: thresholds, context: context))
     }
     
     private let columns = [GridItem(.flexible())]
     
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: columns) {
-                ForEach(viewModel.sessions, id: \.uuid) { session in
-                    ReoredringSessionCard(session: session, thresholds: viewModel.thresholds)
-                        .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.white.opacity(0.8) : Color.clear)
-                        .onDrag({
-                            viewModel.currentlyDraggedSession = session
-                            changedView = false
-                            return NSItemProvider(object: String(describing: session.uuid) as NSString)
-                        })
-                        .onDrop(of: [.text], delegate: DropViewDelegate(sessionAtDropDestination: session, currentlyDraggedSession: $viewModel.currentlyDraggedSession, sessions: $viewModel.sessions, changedView: $changedView))
+            LoadingView(isShowing: $viewModel.isLoading) {
+                LazyVGrid(columns: columns) {
+                    ForEach(viewModel.sessions, id: \.uuid) { session in
+                        ReoredringSessionCard(session: session, thresholds: viewModel.thresholds)
+                            .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.white.opacity(0.8) : Color.clear)
+                            .onDrag({
+                                viewModel.currentlyDraggedSession = session
+                                changedView = false
+                                return NSItemProvider(object: String(describing: session.uuid) as NSString)
+                            })
+                            .onDrop(of: [.text], delegate: DropViewDelegate(sessionAtDropDestination: session, currentlyDraggedSession: $viewModel.currentlyDraggedSession, sessions: $viewModel.sessions, changedView: $changedView))
+                    }
                 }
+                .padding()
             }
-            .padding()
         }
         .onAppear(perform: {
             searchAndFollowButton.isHidden = true

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboardViewModel.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboardViewModel.swift
@@ -3,17 +3,21 @@
 
 import Foundation
 import Resolver
+import CoreData
 
 class ReorderingDashboardViewModel: ObservableObject {
-    @Published var sessions: [Sessionable]
-    var thresholds: [SensorThreshold]
-    
+    @Published var sessions: [Sessionable] = []
+    @Published var isLoading = true
     @Published var currentlyDraggedSession: Sessionable?
+    var thresholds: [SensorThreshold]
+    private var context: NSManagedObjectContext
+    
     @Injected private var uiStorage: UIStorage
     
-    init(sessions: [Sessionable], thresholds: [SensorThreshold]) {
-        self.sessions = sessions
+    init(thresholds: [SensorThreshold], context: NSManagedObjectContext) {
         self.thresholds = thresholds
+        self.context = context
+        fetchSessions()
     }
     
     func finish() {
@@ -21,6 +25,32 @@ class ReorderingDashboardViewModel: ObservableObject {
             self.sessions.reversed().enumerated().forEach { index, session in
                 // TODO: implement new logic for saving new sessions order
                 storage.updateSessionOrder(index + 1, for: session.uuid)
+            }
+        }
+    }
+    
+    private func fetchSessions() {
+        performFetch { self.sessions = $0; self.isLoading = false }
+    }
+    
+    private func performFetch(completion: @escaping ([Sessionable]) -> Void) {
+        context.perform {
+            do {
+                let externalRequest = NSFetchRequest<ExternalSessionEntity>(entityName: "ExternalSessionEntity")
+                externalRequest.sortDescriptors = [NSSortDescriptor(key: "startTime", ascending: false)]
+                
+                let request = NSFetchRequest<SessionEntity>(entityName: "SessionEntity")
+                request.sortDescriptors = [NSSortDescriptor(key: "startTime", ascending: false)]
+                request.predicate = NSPredicate(format: "followedAt != NULL")
+                
+                let sessionEntities = try self.context.fetch(request)
+                let externalSessionEntities = try self.context.fetch(externalRequest)
+                let allSessions: [Sessionable] = (sessionEntities + externalSessionEntities).sorted {
+                    ($0.userInterface?.rowOrder ?? 0) > ($1.userInterface?.rowOrder ?? 0)
+                }
+                completion(allSessions)
+            } catch {
+                Log.error("Failed to fetched sessions for reordering")
             }
         }
     }

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboardViewModel.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboardViewModel.swift
@@ -81,6 +81,7 @@ class ReorderingDashboardViewModel: ObservableObject {
                 completion(allSessions)
             } catch {
                 Log.error("Failed to fetched sessions for reordering")
+                completion([])
             }
         }
     }

--- a/AirCasting/Dashboard/SessionListView.swift
+++ b/AirCasting/Dashboard/SessionListView.swift
@@ -15,6 +15,7 @@ struct SessionsListView: View {
     @StateObject private var coreDataHook: CoreDataHook
     @Binding var isRefreshing: Bool
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
+    @EnvironmentObject var reorderButton: ReorderButton
     
     private let listCoordinateSpaceName = "listCoordinateSpace"
     private let selectedSection: DashboardSection
@@ -33,7 +34,10 @@ struct SessionsListView: View {
                 sessionListView
             }
         }
-        .onAppear { try! coreDataHook.setup(selectedSection: selectedSection) }
+        .onAppear {
+            try! coreDataHook.setup(selectedSection: selectedSection)
+        }
+        .onChange(of: coreDataHook.sessionsCount, perform: { reorderButton.sessionsCountThresholdExceeded = $0 > 1 })
     }
     
     private var sessionListView: some View {

--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -24,13 +24,13 @@ struct MainTabBarView: View {
     @StateObject var finishAndSyncButtonTapped = FinishAndSyncButtonTapped()
     @StateObject var exploreSessionsButton = ExploreSessionsButton()
     @StateObject var sessionContext: CreateSessionContext
-    @StateObject var coreDataHook: CoreDataHook
+//    @StateObject var coreDataHook: CoreDataHook
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     @Environment(\.colorScheme) var colorScheme
     
-    private var sessions: [Sessionable] {
-        coreDataHook.sessions
-    }
+//    private var sessions: [Sessionable] {
+//        coreDataHook.sessions
+//    }
     
     var body: some View {
         ZStack(alignment: .bottomLeading) {
@@ -40,14 +40,16 @@ struct MainTabBarView: View {
                 settingsTab
             }
             Button {
+                //TODO: Add logic for going to either following or active when home button is pressed
                 tabSelection.selection = .dashboard
-                try! coreDataHook.setup(selectedSection: .mobileActive)
-                if sessions.contains(where: { $0.isActive }) {
-                    selectedSection.section = .mobileActive
-                } else {
-                    selectedSection.section = .following
-                }
-                try! coreDataHook.setup(selectedSection: selectedSection.section)
+                selectedSection.section = .following
+//                try! coreDataHook.setup(selectedSection: .mobileActive)
+//                if sessions.contains(where: { $0.isActive }) {
+//                    selectedSection.section = .mobileActive
+//                } else {
+//                    selectedSection.section = .following
+//                }
+//                try! coreDataHook.setup(selectedSection: selectedSection.section)
             } label: {
                 Rectangle()
                     .fill(Color.clear)
@@ -92,7 +94,7 @@ private extension MainTabBarView {
     // Tab Bar views
     private var dashboardTab: some View {
         NavigationView {
-            DashboardView(coreDataHook: coreDataHook)
+            DashboardView()
         }.navigationViewStyle(StackNavigationViewStyle())
             .tabItem {
                 createTabBarImage(homeImage)
@@ -104,7 +106,7 @@ private extension MainTabBarView {
                         if !searchAndFollow.isHidden && featureFlagsViewModel.enabledFeatures.contains(.searchAndFollow) && selectedSection.section == .following {
                             searchAndFollowButton
                         }
-                        if !reorderButton.isHidden && sessions.count > 1 && selectedSection.section == .following {
+                        if !reorderButton.isHidden && reorderButton.sessionsCountThresholdExceeded && selectedSection.section == .following {
                             reorderingButton
                         }
                     }
@@ -229,6 +231,8 @@ class FinishAndSyncButtonTapped: ObservableObject {
 class ReorderButton: ObservableObject {
     @Published var reorderIsOn = false
     @Published var isHidden = false
+    // We only want to show the button for more than one session
+    @Published var sessionsCountThresholdExceeded = false
     
     func setHidden(if isActive: Bool) {
         if isActive {

--- a/AirCasting/RootAppView.swift
+++ b/AirCasting/RootAppView.swift
@@ -54,8 +54,7 @@ struct MainAppView: View {
     var body: some View {
         let shouldPresentLoading = Binding<Bool>(get: { user.currentState == .deletingAccount } , set: { _ in assertionFailure("Unexpected binding setting") })
         LoadingView(isShowing: shouldPresentLoading, activityIndicatorText: Strings.MainTabBarView.deletingAccount) {
-            MainTabBarView(sessionContext: CreateSessionContext(),
-                           coreDataHook: CoreDataHook(context: persistenceController.viewContext))
+            MainTabBarView(sessionContext: CreateSessionContext())
         }
     }
 }


### PR DESCRIPTION
# What was done?

* coreDataHook was removed from MainTabBarView and DashboardView. We are only using it in SessionsListView.
* fetch request was added to MainTabBarView to determine if home button should take user to following or mobile active tab
* fetch request was added to ReorderingDashboard view so display followed sessions
* monitoring for database changes was changed in CoreDataHook. Before we were refreshing the sessions list event if the sessions list didn't change but eg. measurements were downloaded. This resulted in a lot of views being refreshed. Now it is limited.

# Why was it done?

This was done to fix the problem with the disappearing reordering button, but most of the changes were done to improve performance and memory usage.