### PR TITLE
Add swiping right to clear sessions during reordering

### DIFF
--- a/AirCasting/Dashboard/Reordering/CustomSwipeAction.swift
+++ b/AirCasting/Dashboard/Reordering/CustomSwipeAction.swift
@@ -6,18 +6,17 @@ import SwiftUI
 
 /// Adds custom swipe action to a given view
 struct SwipeActionView: ViewModifier {
-    let trailingAction: () -> Void
+    let action: () -> Void
     
     @State private var offset: CGFloat = 0
-    @State private var prevOffset: CGFloat = 0
     
-    init(trailingAction: @escaping () -> Void) {
-        self.trailingAction = trailingAction
+    init(action: @escaping () -> Void) {
+        self.action = action
     }
     
     func body(content: Content) -> some View {
         content
-            .offset(x: (offset > 0) ? 0 : offset)
+            .offset(x: offset)
         // animate the view as `offset` changes
             .animation(.spring(), value: offset)
         // allows the DragGesture to work even if there are now interactable
@@ -31,8 +30,11 @@ struct SwipeActionView: ViewModifier {
                     offset = gesture.translation.width
                 }
                 .onEnded { _ in
-                    checkAndHandleFullSwipe(for: trailingAction, edge: .trailing, width: -UIScreen.main.bounds.size.width)
-                    prevOffset = offset
+                    if offset < 0 {
+                        checkAndHandleFullSwipe(for: action, edge: .trailing, width: -UIScreen.main.bounds.size.width)
+                    } else {
+                        checkAndHandleFullSwipe(for: action, edge: .leading, width: UIScreen.main.bounds.size.width)
+                    }
                 })
     }
     
@@ -66,7 +68,7 @@ struct SwipeActionView: ViewModifier {
 }
 
 extension View {
-    func trailingSwipeAction(action: @escaping () -> Void) -> some View {
-        modifier(SwipeActionView(trailingAction: action))
+    func swipeAction(action: @escaping () -> Void) -> some View {
+        modifier(SwipeActionView(action: action))
     }
 }

--- a/AirCasting/Dashboard/Reordering/DropViewDelegate.swift
+++ b/AirCasting/Dashboard/Reordering/DropViewDelegate.swift
@@ -34,6 +34,10 @@ struct DropViewDelegate: DropDelegate {
         currentlyDraggedSession = nil
         return true
     }
+    
+    func dropExited(info: DropInfo) {
+        changedView = false
+    }
 }
 
 struct DropOutsideOfGridDelegate: DropDelegate {

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -27,7 +27,7 @@ struct ReorderingDashboard: View {
                             return NSItemProvider(object: String(describing: session.uuid) as NSString)
                         })
                         .onDrop(of: [.text], delegate: DropViewDelegate(sessionAtDropDestination: session, currentlyDraggedSession: $viewModel.currentlyDraggedSession, sessions: $viewModel.sessions, changedView: $changedView))
-                        .trailingSwipeAction {
+                        .swipeAction {
                             withAnimation(.easeOut(duration: 0.5)) {
                                 viewModel.clear(session: session)
                             }

--- a/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
+++ b/AirCasting/Dashboard/Reordering/ReorderingDashboard.swift
@@ -23,7 +23,6 @@ struct ReorderingDashboard: View {
                         .overlay(viewModel.currentlyDraggedSession?.uuid == session.uuid && changedView ? Color.aircastingWhite.opacity(0.8) : Color.clear)
                         .onDrag({
                             viewModel.currentlyDraggedSession = session
-                            changedView = false
                             return NSItemProvider(object: String(describing: session.uuid) as NSString)
                         })
                         .onDrop(of: [.text], delegate: DropViewDelegate(sessionAtDropDestination: session, currentlyDraggedSession: $viewModel.currentlyDraggedSession, sessions: $viewModel.sessions, changedView: $changedView))


### PR DESCRIPTION
# What was done?
This PR enables unfollowing sessions during reordering by swiping the session card to the right. Before only swiping left was enabled.