### PR TITLE
Prevents a UI from showing fetching and sync at the same time.

### DIFF
--- a/AirCasting/Dashboard/EmptyFixedDashboardView.swift
+++ b/AirCasting/Dashboard/EmptyFixedDashboardView.swift
@@ -12,7 +12,7 @@ struct EmptyFixedDashboardView: View {
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     
     var shouldSessionFetch: Bool {
-        (selectedSection.section == .mobileDormant || selectedSection.section == .fixed) && defaultSessionSynchronizerViewModel.syncInProgress
+        selectedSection.section == .fixed && defaultSessionSynchronizerViewModel.syncInProgress
     }
     
     var body: some View {

--- a/AirCasting/Dashboard/EmptyMobileDashboardView.swift
+++ b/AirCasting/Dashboard/EmptyMobileDashboardView.swift
@@ -14,7 +14,7 @@ struct EmptyMobileDashboardViewMobile: View {
     @EnvironmentObject var selectedSection: SelectedSection
     
     var shouldSessionFetch: Bool {
-        (selectedSection.section == .mobileDormant || selectedSection.section == .fixed) && defaultSessionSynchronizerViewModel.syncInProgress
+        selectedSection.section == .mobileDormant && defaultSessionSynchronizerViewModel.syncInProgress
     }
     
     var body: some View {

--- a/AirCasting/Dashboard/RefreshControl.swift
+++ b/AirCasting/Dashboard/RefreshControl.swift
@@ -6,18 +6,21 @@ import SwiftUI
 struct RefreshControl: View {
     let coordinateSpace: CoordinateSpace
     @Binding var isRefreshing: Bool
+    @Binding var isBlocked: Bool
     
     private let pullToRefreshThreshold: CGFloat = 50
     
     var body: some View {
         GeometryReader { geometry in
-            if shouldStartRefreshing(using: geometry) {
-                startRefreshing()
+            if !isBlocked {
+                if shouldStartRefreshing(using: geometry) {
+                    startRefreshing()
+                }
+                ZStack(alignment: .center) {
+                    if isRefreshing { ProgressView(Strings.RefreshControl.progressViewTest) } else { mimicPullToRefreshAnimation(with: geometry) }
+                }
+                .frame(width: geometry.size.width)
             }
-            ZStack(alignment: .center) {
-                if isRefreshing { ProgressView(Strings.RefreshControl.progressViewTest) } else { mimicPullToRefreshAnimation(with: geometry) }
-            }
-            .frame(width: geometry.size.width)
         }
         // paddings: for non-refreshing state we need negative top padding to hide
         // the refresh control correctly under the top part of a parent view.


### PR DESCRIPTION
**The problem:**

When the user logs in and "Fetching..." is happening, he pulls down to start sync - both spinners show up.

**The solution:**

Do not allow a user to pull down for sync when the first-time "Fetching..." is happening.