### PR TITLE
Make stream an optional when checking inserted measurements

### DIFF
--- a/AirCasting/SessionViews/ChartDatabaseObserver.swift
+++ b/AirCasting/SessionViews/ChartDatabaseObserver.swift
@@ -32,9 +32,9 @@ final class ChartDatabaseObserver {
     @objc private func contextChanged(_ n: Notification) {
         guard let insertedObjects = (n.userInfo?[NSInsertedObjectsKey] as? NSSet)?.allObjects else { return }
         let insertedMeasurements = insertedObjects.compactMap { $0 as? MeasurementEntity }
-        let filtered = insertedMeasurements.filter { $0.measurementStream.session?.uuid.rawValue == session ||
-            $0.measurementStream.externalSession?.uuid.rawValue == session &&
-            $0.measurementStream.sensorName == sensor }
+        let filtered = insertedMeasurements.filter { $0.measurementStream?.session?.uuid.rawValue == session ||
+            $0.measurementStream?.externalSession?.uuid.rawValue == session &&
+            $0.measurementStream?.sensorName == sensor }
         guard let newestMeasurement = filtered.sorted(by: { $0.time > $1.time }).first else { return }
         defer { latestMeasurementTime = newestMeasurement.time }
         guard filtered.count > 0, shouldFireObserver(newMeasurement: newestMeasurement) else { return }


### PR DESCRIPTION
It happened to me that after SD sync the app crashed because $0.measurementStream was nil so I think we should check it just to be sure