### PR TITLE
Fix heatmap - wrong colors

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -223,7 +223,7 @@
 		AC8CFF7725ECF8B100FB2918 /* HexMessagesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8CFF7625ECF8B100FB2918 /* HexMessagesBuilder.swift */; };
 		AC8CFF7E25EE5F9200FB2918 /* AirBeam3Configurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8CFF7D25EE5F9200FB2918 /* AirBeam3Configurator.swift */; };
 		AC8D6C6A25C049E300ED74D1 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8D6C6925C049E300ED74D1 /* Environment.swift */; };
-		AC8D6C6E25C056B400ED74D1 /* PathPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8D6C6D25C056B400ED74D1 /* PathPoint.swift */; };
+		AC8D6C6E25C056B400ED74D1 /* HeatMapPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8D6C6D25C056B400ED74D1 /* HeatMapPoint.swift */; };
 		AC8D6C7225C0574800ED74D1 /* LocationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8D6C7125C0574800ED74D1 /* LocationTracker.swift */; };
 		AC93B8DA25BEDC46003D0A0D /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC93B8D925BEDC46003D0A0D /* Array.swift */; };
 		AC93B8E725BEFE4F003D0A0D /* SessionMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC93B8E625BEFE4F003D0A0D /* SessionMapView.swift */; };
@@ -822,7 +822,7 @@
 		AC8CFF7625ECF8B100FB2918 /* HexMessagesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexMessagesBuilder.swift; sourceTree = "<group>"; };
 		AC8CFF7D25EE5F9200FB2918 /* AirBeam3Configurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirBeam3Configurator.swift; sourceTree = "<group>"; };
 		AC8D6C6925C049E300ED74D1 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
-		AC8D6C6D25C056B400ED74D1 /* PathPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathPoint.swift; sourceTree = "<group>"; };
+		AC8D6C6D25C056B400ED74D1 /* HeatMapPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatMapPoint.swift; sourceTree = "<group>"; };
 		AC8D6C7125C0574800ED74D1 /* LocationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationTracker.swift; sourceTree = "<group>"; };
 		AC93B8D925BEDC46003D0A0D /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		AC93B8E625BEFE4F003D0A0D /* SessionMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMapView.swift; sourceTree = "<group>"; };
@@ -1904,7 +1904,7 @@
 				DD8DE68A2785B939009B1726 /* MapNotesViewModel.swift */,
 				AC93B8E625BEFE4F003D0A0D /* SessionMapView.swift */,
 				AC8D6C7125C0574800ED74D1 /* LocationTracker.swift */,
-				AC8D6C6D25C056B400ED74D1 /* PathPoint.swift */,
+				AC8D6C6D25C056B400ED74D1 /* HeatMapPoint.swift */,
 				AC8D6C6925C049E300ED74D1 /* Environment.swift */,
 			);
 			path = Map;
@@ -3601,7 +3601,7 @@
 				ACCEB2242763A2230040140B /* SyncingABView.swift in Sources */,
 				3375E8CF279185430019A5DE /* TemperatureConverter.swift in Sources */,
 				33831B1B29154E7E0097020C /* ReconnectionController.swift in Sources */,
-				AC8D6C6E25C056B400ED74D1 /* PathPoint.swift in Sources */,
+				AC8D6C6E25C056B400ED74D1 /* HeatMapPoint.swift in Sources */,
 				B30BAC172694AA8000AE0476 /* MeasurementsStatisticsOutput.swift in Sources */,
 				DD7955492757B30F00631A78 /* InAppAlerts.swift in Sources */,
 				DD197FA927BE43A900340672 /* MapDownloaderMeasurementType.swift in Sources */,

--- a/AirCasting/Graph/StatisticsContainer/Adapters/MapStatsDataSource.swift
+++ b/AirCasting/Graph/StatisticsContainer/Adapters/MapStatsDataSource.swift
@@ -12,7 +12,7 @@ class MapStatsDataSource: MeasurementsStatisticsDataSource, ObservableObject {
     
     var onForceReload: (() -> Void)?
     
-    var visiblePathPoints: [PathPoint]
+    var visiblePathPoints: [_MapView.PathPoint]
     
     init() {
         self.visiblePathPoints = []

--- a/AirCasting/Map/HeatMapPoint.swift
+++ b/AirCasting/Map/HeatMapPoint.swift
@@ -1,5 +1,5 @@
 //
-//  PathPoint.swift
+//  HeatMapPoint.swift
 //  AirCasting
 //
 //  Created by Monika Śmiałko on 26/01/2021.
@@ -8,15 +8,13 @@
 import Foundation
 import CoreLocation
 
-struct PathPoint: Equatable {
-    static func == (lhs: PathPoint, rhs: PathPoint) -> Bool {
-        rhs.measurementTime == lhs.measurementTime &&
+struct HeatMapPoint: Equatable {
+    static func == (lhs: HeatMapPoint, rhs: HeatMapPoint) -> Bool {
         rhs.measurement == lhs.measurement &&
         rhs.location.latitude == lhs.location.latitude &&
         rhs.location.longitude == lhs.location.longitude
     }
     
     let location: CLLocationCoordinate2D
-    let measurementTime: Date
     var measurement: Double
 }

--- a/AirCasting/Map/Heatmap/GridSquare.swift
+++ b/AirCasting/Map/Heatmap/GridSquare.swift
@@ -37,7 +37,7 @@ struct GridSquare {
         self.polygon = GMSPolygon(path: rect)
     }
     
-    mutating func addMeasurement(_ pathPoint: PathPoint) {
+    mutating func addMeasurement(_ pathPoint: HeatMapPoint) {
         sum += pathPoint.measurement
         number += 1
         calculateAverage()

--- a/AirCasting/Map/Heatmap/Heatmap.swift
+++ b/AirCasting/Map/Heatmap/Heatmap.swift
@@ -51,7 +51,7 @@ struct Heatmap {
         initGrid()
     }
     
-    mutating func drawHeatMap(pathPoints: [PathPoint]) {
+    mutating func drawHeatMap(pathPoints: [HeatMapPoint]) {
         for pathPoint in pathPoints {
             assignMeasurementToSquare(pathPoint)
         }
@@ -81,14 +81,14 @@ struct Heatmap {
         setGridSquare(x, y, nil)
     }
     
-    private mutating func assignMeasurementToSquare(_ pathPoint: PathPoint) {
+    private mutating func assignMeasurementToSquare(_ pathPoint: HeatMapPoint) {
         guard let squareXY = getSquareXY(pathPoint, indexXstart: 0, indexXend: gridSizeX - 1, indexYstart: 0, indexYend: gridSizeY - 1) else { return }
         var gridSquare = getGridSquare(x: squareXY.0, y: squareXY.1)
         gridSquare?.addMeasurement(pathPoint)
         setGridSquare(x: squareXY.0, y: squareXY.1, gridSquare: gridSquare)
     }
     
-    private func getSquareXY(_ pathPoint: PathPoint, indexXstart: Int, indexXend: Int, indexYstart: Int, indexYend: Int) -> (Int, Int)? {
+    private func getSquareXY(_ pathPoint: HeatMapPoint, indexXstart: Int, indexXend: Int, indexYstart: Int, indexYend: Int) -> (Int, Int)? {
         let middleX = indexXstart  + (indexXend - indexXstart) / 2
         let middleY = indexYstart  + (indexYend - indexYstart) / 2
         let middleSquare = getGridSquare(x: middleX + 1, y: middleY + 1)

--- a/AirCasting/Map/_Map/_MapViewThresholdFormatter.swift
+++ b/AirCasting/Map/_Map/_MapViewThresholdFormatter.swift
@@ -10,7 +10,6 @@ class _MapViewThresholdFormatter {
     
     func color(points: [_MapView.PathPoint], threshold: SensorThreshold) -> UIColor {
         let formatter = Resolver.resolve(ThresholdFormatter.self, args: threshold)
-        
         guard let point = points.last else { return .white }
         let measurement = formatter.value(from: point.value)
         return getProperColor(value: measurement, threshold: threshold)


### PR DESCRIPTION
https://trello.com/c/7FeVqntE/861-mobile-active-heatmap-colors-inaccurate
When seeing a heatMap, it tends to change immediately out of nowhere. Please use `Path` session which can be found on mobile dormant section in Michael's account to test.

To test: Use the `RH` param and zoom in to see a path, and it changes a lot. Now switch to Pm.2.5 and RH again. You should see that Pm2.5 overlaps RH, even when RH is chosen.