### PR TITLE
TabBar management refined

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		FA5F7847289AB7C20016DF79 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5F7846289AB7C20016DF79 /* SearchViewModelTests.swift */; };
 		FA63D212289C0282002A4BD5 /* DatabaseDeviceUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA63D211289C0282002A4BD5 /* DatabaseDeviceUUID.swift */; };
 		FA724D912927AC9F00C9EFE3 /* _MapViewThresholdFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA724D902927AC9F00C9EFE3 /* _MapViewThresholdFormatter.swift */; };
+		FA89DE8F2BB6BBE600619B73 /* TabBarSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA89DE8E2BB6BBE600619B73 /* TabBarSelector.swift */; };
 		FA94089A2886D3FE0022E1A5 /* BluetoothProtectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9408992886D3FE0022E1A5 /* BluetoothProtectorTests.swift */; };
 		FAAB48FD290BC9EF000BDBEE /* ReconnectSessionCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAB48FC290BC9EF000BDBEE /* ReconnectSessionCardViewModel.swift */; };
 		FAB1D4A427FAD83E004F531D /* BottomCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB1D4A327FAD83E004F531D /* BottomCardViewModel.swift */; };
@@ -1163,6 +1164,7 @@
 		FA5F7846289AB7C20016DF79 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		FA63D211289C0282002A4BD5 /* DatabaseDeviceUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseDeviceUUID.swift; sourceTree = "<group>"; };
 		FA724D902927AC9F00C9EFE3 /* _MapViewThresholdFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _MapViewThresholdFormatter.swift; sourceTree = "<group>"; };
+		FA89DE8E2BB6BBE600619B73 /* TabBarSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarSelector.swift; sourceTree = "<group>"; };
 		FA9408992886D3FE0022E1A5 /* BluetoothProtectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothProtectorTests.swift; sourceTree = "<group>"; };
 		FA9E08C828926C07006475D6 /* AirCasting v8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "AirCasting v8.xcdatamodel"; sourceTree = "<group>"; };
 		FAAB48FC290BC9EF000BDBEE /* ReconnectSessionCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectSessionCardViewModel.swift; sourceTree = "<group>"; };
@@ -1779,7 +1781,7 @@
 				FA1C30BC2861BA5F0034C1C9 /* SignInPersistance.swift */,
 				AC7EB37525A6FB3A00A7F2AF /* AirCastingApp.swift */,
 				ACD01F912600A3C800B8F65F /* RootAppView.swift */,
-				AC7EB37725A6FB3A00A7F2AF /* MainTabBarView.swift */,
+				FA89DE8D2BB6BBCB00619B73 /* TabBar */,
 				FAF3B4E428058B6700F0F4B0 /* ProtectedScreen.swift */,
 				B3F1448126AE4CD9006A4612 /* OfflineMessageViewModel.swift */,
 				DD430AFE2670BB3000F1BF2E /* Onboarding */,
@@ -2972,6 +2974,15 @@
 			path = AirCastingUITests;
 			sourceTree = "<group>";
 		};
+		FA89DE8D2BB6BBCB00619B73 /* TabBar */ = {
+			isa = PBXGroup;
+			children = (
+				AC7EB37725A6FB3A00A7F2AF /* MainTabBarView.swift */,
+				FA89DE8E2BB6BBE600619B73 /* TabBarSelector.swift */,
+			);
+			path = TabBar;
+			sourceTree = "<group>";
+		};
 		FAAB48FB290BC9D5000BDBEE /* ReconnectSessionCard */ = {
 			isa = PBXGroup;
 			children = (
@@ -3494,6 +3505,7 @@
 				332B993F2937B96C00C0D15D /* SDSyncMeasurementsStorage.swift in Sources */,
 				332020A8283CF724003E07F3 /* SessionEntity+Sessionable.swift in Sources */,
 				AC5832DA25B196DD008C5DD5 /* Graph.swift in Sources */,
+				FA89DE8F2BB6BBE600619B73 /* TabBarSelector.swift in Sources */,
 				AC4A6A6A267CB3890001F639 /* AirCastingGraph.swift in Sources */,
 				DD197FA727BE439200340672 /* MapDownloaderUnitSymbol.swift in Sources */,
 				DD197FA727BE439200340672 /* MapDownloaderUnitSymbol.swift in Sources */,

--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
@@ -10,7 +10,7 @@ import AirCastingStyling
 import Resolver
 
 struct ChooseSessionTypeView: View {
-    @EnvironmentObject private var tabSelection: TabBarSelection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     @EnvironmentObject private var emptyDashboardButtonTapped: EmptyDashboardButtonTapped
     @EnvironmentObject private var finishAndSyncButtonTapped: FinishAndSyncButtonTapped
     @EnvironmentObject private var exploreSessionsButton: ExploreSessionsButton

--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -21,7 +21,7 @@ struct ConfirmCreatingSessionView: View {
     @EnvironmentObject var selectedSection: SelectedSection
     @EnvironmentObject private var sessionContext: CreateSessionContext
     @Injected private var locationTracker: LocationTracker
-    @EnvironmentObject private var tabSelection: TabBarSelection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     @Binding var creatingSessionFlowContinues: Bool
 
     let initialLocation: CLLocation?
@@ -158,7 +158,7 @@ extension ConfirmCreatingSessionView {
                     } else {
                         selectedSection.section = .following
                     }
-                    tabSelection.selection = TabBarSelection.Tab.dashboard
+                    tabSelection.updateSelection(to: .dashboard)
 
                 case .failure(let error):
                     self.error = error as NSError

--- a/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
+++ b/AirCasting/CreateSessionViews/ConfirmCreatingSessionView.swift
@@ -158,7 +158,7 @@ extension ConfirmCreatingSessionView {
                     } else {
                         selectedSection.section = .following
                     }
-                    tabSelection.updateSelection(to: .dashboard)
+                    tabSelection.update(to: .dashboard)
 
                 case .failure(let error):
                     self.error = error as NSError

--- a/AirCasting/CreateSessionViews/SelectDeviceView.swift
+++ b/AirCasting/CreateSessionViews/SelectDeviceView.swift
@@ -22,7 +22,6 @@ struct SelectDeviceView: View {
     @Binding var creatingSessionFlowContinues : Bool
     @Binding var sdSyncContinues : Bool
     @EnvironmentObject private var emptyDashboardButtonTapped: EmptyDashboardButtonTapped
-    @EnvironmentObject private var tabSelection: TabBarSelection
 
     var body: some View {
         VStack(spacing: 30) {

--- a/AirCasting/Dashboard/DashboardView.swift
+++ b/AirCasting/Dashboard/DashboardView.swift
@@ -24,13 +24,9 @@ struct DashboardView: View {
     @Injected private var networkChecker: NetworkChecker
     @Injected private var persistenceController: PersistenceController
     private let sessionSynchronizer: SessionSynchronizer
-
-    private var sessions: [Sessionable] {
-        coreDataHook.sessions
-    }
     
     private var noDormantNorFixedSessions: Bool {
-        !sessions.contains(where: { $0.isFixed || !$0.isActive })
+        !coreDataHook.sessions.contains(where: { $0.isFixed || !$0.isActive })
     }
 
     init(coreDataHook: CoreDataHook, measurementsDownloadingInProgress: Binding<Bool>) {
@@ -48,7 +44,7 @@ struct DashboardView: View {
                 .alert(item: $alert, content: { $0.makeAlert() })
             if reorderButton.reorderIsOn {
                 followingReorderTab
-                ReorderingDashboard(sessions: sessions,
+                ReorderingDashboard(sessions: coreDataHook.sessions,
                                     thresholds: Array(self.thresholds))
             } else {
                 sessionTypePicker
@@ -99,7 +95,7 @@ struct DashboardView: View {
         }
         .onChange(of: selectedSection.mobileSessionWasFinished) { newValue in
             if newValue &&
-                sessions.count == 1 {
+                coreDataHook.sessions.count == 1 {
                 selectedSection.section = .mobileDormant
             }
             selectedSection.mobileSessionWasFinished = false

--- a/AirCasting/Dashboard/EmptyDashboardButtonView.swift
+++ b/AirCasting/Dashboard/EmptyDashboardButtonView.swift
@@ -14,7 +14,7 @@ struct EmptyDashboardButtonView: View {
         Button(action: {
             emptyDashboardButtonTapped.mobileWasTapped = !isFixed
             exploreSessionsButton.exploreSessionsButtonTapped = false
-            tabSelection.updateSelection(to: .createSession)
+            tabSelection.update(to: .createSession)
         }, label: {
             if isFixed {
                 Text(Strings.EmptyDashboardMobile.buttonFixed)

--- a/AirCasting/Dashboard/EmptyDashboardButtonView.swift
+++ b/AirCasting/Dashboard/EmptyDashboardButtonView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import AirCastingStyling
 
 struct EmptyDashboardButtonView: View {
-    @EnvironmentObject private var tabSelection: TabBarSelection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     @EnvironmentObject private var emptyDashboardButtonTapped: EmptyDashboardButtonTapped
     @EnvironmentObject private var exploreSessionsButton: ExploreSessionsButton
     var isFixed: Bool
@@ -14,7 +14,7 @@ struct EmptyDashboardButtonView: View {
         Button(action: {
             emptyDashboardButtonTapped.mobileWasTapped = !isFixed
             exploreSessionsButton.exploreSessionsButtonTapped = false
-            tabSelection.selection = .createSession
+            tabSelection.updateSelection(to: .createSession)
         }, label: {
             if isFixed {
                 Text(Strings.EmptyDashboardMobile.buttonFixed)

--- a/AirCasting/Dashboard/EmptyFixedDashboardView.swift
+++ b/AirCasting/Dashboard/EmptyFixedDashboardView.swift
@@ -39,7 +39,7 @@ private extension EmptyFixedDashboardView {
     private var exploreExistingSessionsButton: some View {
         Button(action: {
             exploreSessionsButton.exploreSessionsButtonTapped = true
-            tabSelection.updateSelection(to: .createSession)
+            tabSelection.update(to: .createSession)
         }, label: {
             Text(Strings.EmptyDashboardFixed.exploreSessionsButton)
                 .font(Fonts.moderateBoldHeading1)

--- a/AirCasting/Dashboard/EmptyFixedDashboardView.swift
+++ b/AirCasting/Dashboard/EmptyFixedDashboardView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import Resolver
 
 struct EmptyFixedDashboardView: View {
-    @EnvironmentObject private var tabSelection: TabBarSelection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     @EnvironmentObject private var exploreSessionsButton: ExploreSessionsButton
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     
@@ -39,7 +39,7 @@ private extension EmptyFixedDashboardView {
     private var exploreExistingSessionsButton: some View {
         Button(action: {
             exploreSessionsButton.exploreSessionsButtonTapped = true
-            tabSelection.selection = .createSession
+            tabSelection.updateSelection(to: .createSession)
         }, label: {
             Text(Strings.EmptyDashboardFixed.exploreSessionsButton)
                 .font(Fonts.moderateBoldHeading1)

--- a/AirCasting/SDSync/ViewsFlow/SDSyncComplete/SDSyncCompleteView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncComplete/SDSyncCompleteView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 struct SDSyncCompleteView<VM: SDSyncCompleteViewModel>: View {
     @StateObject var viewModel: VM
     @Binding var creatingSessionFlowContinues: Bool
-    @EnvironmentObject private var tabSelection: TabBarSelection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     var isSDClearProcess: Bool
     
     var body: some View {
@@ -54,7 +54,7 @@ private extension SDSyncCompleteView {
     var continueButton: some View {
         Button {
             creatingSessionFlowContinues = false
-            tabSelection.selection = TabBarSelection.Tab.dashboard
+            tabSelection.updateSelection(to: .dashboard)
         } label: {
             Text(Strings.Commons.continue)
         }

--- a/AirCasting/SDSync/ViewsFlow/SDSyncComplete/SDSyncCompleteView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncComplete/SDSyncCompleteView.swift
@@ -54,7 +54,7 @@ private extension SDSyncCompleteView {
     var continueButton: some View {
         Button {
             creatingSessionFlowContinues = false
-            tabSelection.updateSelection(to: .dashboard)
+            tabSelection.update(to: .dashboard)
         } label: {
             Text(Strings.Commons.continue)
         }

--- a/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
@@ -237,7 +237,7 @@ private extension SearchMapView {
     var finishButton: some View {
         Button {
             isSearchAndFollowLinkActive = false
-            tabSelection.updateSelection(to: .dashboard)
+            tabSelection.update(to: .dashboard)
             selectedSection.section = .following
         } label: {
             Text(Strings.SearchMapView.finishText)

--- a/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/SearchMapView.swift
@@ -12,7 +12,7 @@ struct SearchMapView: View {
     @StateObject private var viewModel: SearchMapViewModel
     @Environment(\.presentationMode) var presentationMode
     @Binding var isSearchAndFollowLinkActive: Bool
-    @EnvironmentObject var tabSelection: TabBarSelection
+    @EnvironmentObject var tabSelection: TabBarSelector
     @EnvironmentObject var selectedSection: SelectedSection
     @Environment(\.colorScheme) var colorScheme
     
@@ -237,7 +237,7 @@ private extension SearchMapView {
     var finishButton: some View {
         Button {
             isSearchAndFollowLinkActive = false
-            tabSelection.selection = .dashboard
+            tabSelection.updateSelection(to: .dashboard)
             selectedSection.section = .following
         } label: {
             Text(Strings.SearchMapView.finishText)

--- a/AirCasting/SessionViews/SessionCardView.swift
+++ b/AirCasting/SessionViews/SessionCardView.swift
@@ -19,6 +19,7 @@ struct SessionCardView: View {
     @State private var showLoadingIndicator = false
     @ObservedObject var session: SessionEntity
     @EnvironmentObject var selectedSection: SelectedSection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     @EnvironmentObject var reorderButton: ReorderButton
     @EnvironmentObject var searchAndFollowButton: SearchAndFollowButton
     let sessionCartViewModel: SessionCardViewModel
@@ -101,6 +102,10 @@ struct SessionCardView: View {
             reorderButton.setHidden(if: isGraphButtonActive)
             searchAndFollowButton.setHidden(if: isGraphButtonActive)
         }
+        .onReceive(tabSelection.dashboardSelectionNotifier, perform: { _ in
+            isMapButtonActive = false
+            isGraphButtonActive = false
+        })
         .font(Fonts.moderateRegularHeading4)
         .foregroundColor(.aircastingGray)
         .padding()

--- a/AirCasting/SessionViews/StandaloneSessionCardView.swift
+++ b/AirCasting/SessionViews/StandaloneSessionCardView.swift
@@ -7,7 +7,7 @@ import Resolver
 
 struct StandaloneSessionCardView: View {
     let session: SessionEntity
-    @EnvironmentObject private var tabSelection: TabBarSelection
+    @EnvironmentObject private var tabSelection: TabBarSelector
     @EnvironmentObject private var finishAndSyncButtonTapped: FinishAndSyncButtonTapped
     @EnvironmentObject var selectedSection: SelectedSection
     @Injected private var networkChecker: NetworkChecker
@@ -87,7 +87,7 @@ struct StandaloneSessionCardView: View {
 
     func finishSessionAndSyncAlertAction() {
         finishAndSyncButtonTapped.finishAndSyncButtonWasTapped = true
-        tabSelection.selection = .createSession
+        tabSelection.updateSelection(to: .createSession)
         selectedSection.mobileSessionWasFinished = true
     }
     

--- a/AirCasting/SessionViews/StandaloneSessionCardView.swift
+++ b/AirCasting/SessionViews/StandaloneSessionCardView.swift
@@ -87,7 +87,7 @@ struct StandaloneSessionCardView: View {
 
     func finishSessionAndSyncAlertAction() {
         finishAndSyncButtonTapped.finishAndSyncButtonWasTapped = true
-        tabSelection.updateSelection(to: .createSession)
+        tabSelection.update(to: .createSession)
         selectedSection.mobileSessionWasFinished = true
     }
     

--- a/AirCasting/TabBar/MainTabBarView.swift
+++ b/AirCasting/TabBar/MainTabBarView.swift
@@ -29,7 +29,7 @@ struct MainTabBarView: View {
             TabView(selection: .init(get: {
                 tabSelection.selection
             }, set: { newSelection in
-                tabSelection.updateSelection(to: newSelection)
+                tabSelection.update(to: newSelection)
             })) {
                 dashboardTab
                 createSessionTab
@@ -74,14 +74,12 @@ struct MainTabBarView: View {
     }
     
     private func dashboardTapped() {
-        tabSelection.updateSelection(to: .dashboard)
-        
+        tabSelection.update(to: .dashboard)
         if !coreDataHook.getSessionsFor(section: .mobileActive).isEmpty {
             selectedSection.section = .mobileActive
         } else {
             selectedSection.section = .following
         }
-        
         try! coreDataHook.setup(selectedSection: selectedSection.section)
     }
 }

--- a/AirCasting/TabBar/MainTabBarView.swift
+++ b/AirCasting/TabBar/MainTabBarView.swift
@@ -11,10 +11,7 @@ import Resolver
 
 struct MainTabBarView: View {
     @Injected private var measurementUpdatingService: MeasurementUpdatingService
-    @State var homeImage: String = HomeIcon.selected.string
-    @State var settingsImage: String = SettingsIcon.unselected.string
-    @State var plusImage: String = PlusIcon.unselected.string
-    @StateObject var tabSelection: TabBarSelection = TabBarSelection()
+    @StateObject var tabSelection: TabBarSelector = TabBarSelector()
     @StateObject var selectedSection = SelectedSection()
     @StateObject var reorderButton = ReorderButton()
     @StateObject var searchAndFollow = SearchAndFollowButton()
@@ -27,26 +24,19 @@ struct MainTabBarView: View {
     @Environment(\.colorScheme) var colorScheme
     @State var measurementsDownloadingInProgress = false
     
-    private var sessions: [Sessionable] {
-        coreDataHook.sessions
-    }
-    
     var body: some View {
         ZStack(alignment: .bottomLeading) {
-            TabView(selection: $tabSelection.selection) {
+            TabView(selection: .init(get: {
+                tabSelection.selection
+            }, set: { newSelection in
+                tabSelection.updateSelection(to: newSelection)
+            })) {
                 dashboardTab
                 createSessionTab
                 settingsTab
             }
             Button {
-                tabSelection.selection = .dashboard
-                try! coreDataHook.setup(selectedSection: .mobileActive)
-                if sessions.contains(where: { $0.isActive }) {
-                    selectedSection.section = .mobileActive
-                } else {
-                    selectedSection.section = .following
-                }
-                try! coreDataHook.setup(selectedSection: selectedSection.section)
+                dashboardTapped()
             } label: {
                 Rectangle()
                     .fill(Color.clear)
@@ -54,34 +44,17 @@ struct MainTabBarView: View {
             }
             
         }
-        .onAppCameToForeground {
-            measurementsDownloadingInProgress = true
-            measurementUpdatingService.updateAllSessionsMeasurements() {
-                DispatchQueue.main.async {
-                    measurementsDownloadingInProgress = false
-                }
-            }
-        }
+        .onAppCameToForeground { performSessionsUpdate() }
         .onAppear {
-            UITabBar.appearance().backgroundColor = .aircastingBackground
             let appearance = UITabBarAppearance()
             appearance.backgroundImage = UIImage()
             appearance.shadowImage = UIImage.mainTabBarShadow
+            appearance.backgroundColor = .aircastingBackground
             UITabBar.appearance().standardAppearance = appearance
-            measurementsDownloadingInProgress = true
-            measurementUpdatingService.updateAllSessionsMeasurements() {
-                DispatchQueue.main.async {
-                    measurementsDownloadingInProgress = false
-                }
-            }
+            
+            performSessionsUpdate()
             measurementUpdatingService.start()
         }
-        .onChange(of: tabSelection.selection, perform: { _ in
-            tabSelection.selection == .dashboard ? (homeImage = HomeIcon.selected.string) : (homeImage = HomeIcon.unselected.string)
-            tabSelection.selection == .settings ? (settingsImage = SettingsIcon.selected.string) : (settingsImage = SettingsIcon.unselected.string)
-            tabSelection.selection == .createSession ? (plusImage = PlusIcon.selected.string) : (plusImage = PlusIcon.unselected.string)
-            
-        })
         .environmentObject(selectedSection)
         .environmentObject(tabSelection)
         .environmentObject(emptyDashboardButtonTapped)
@@ -90,25 +63,45 @@ struct MainTabBarView: View {
         .environmentObject(reorderButton)
         .environmentObject(searchAndFollow)
     }
+    
+    private func performSessionsUpdate() {
+        measurementsDownloadingInProgress = true
+        measurementUpdatingService.updateAllSessionsMeasurements() {
+            DispatchQueue.main.async {
+                measurementsDownloadingInProgress = false
+            }
+        }
+    }
+    
+    private func dashboardTapped() {
+        tabSelection.updateSelection(to: .dashboard)
+        
+        if !coreDataHook.getSessionsFor(section: .mobileActive).isEmpty {
+            selectedSection.section = .mobileActive
+        } else {
+            selectedSection.section = .following
+        }
+        
+        try! coreDataHook.setup(selectedSection: selectedSection.section)
+    }
 }
 
 private extension MainTabBarView {
-    // Tab Bar views
     private var dashboardTab: some View {
         NavigationView {
             DashboardView(coreDataHook: coreDataHook, measurementsDownloadingInProgress: $measurementsDownloadingInProgress)
         }.navigationViewStyle(StackNavigationViewStyle())
             .tabItem {
-                createTabBarImage(homeImage)
+                createTabBarImage(tabSelection.getImageFor(.dashboard))
             }
-            .tag(TabBarSelection.Tab.dashboard)
+            .tag(TabBarSelector.Tab.dashboard)
             .overlay(
                 Group{
                     HStack {
                         if !searchAndFollow.isHidden && featureFlagsViewModel.enabledFeatures.contains(.searchAndFollow) && selectedSection.section == .following {
                             searchAndFollowButton
                         }
-                        if reorderButton.reorderIsOn || (!reorderButton.isHidden && sessions.count > 1 && selectedSection.section == .following) {
+                        if reorderButton.reorderIsOn || (!reorderButton.isHidden && coreDataHook.sessions.count > 1 && selectedSection.section == .following) {
                             reorderingButton
                         }
                     }
@@ -120,17 +113,17 @@ private extension MainTabBarView {
     private var createSessionTab: some View {
         ChooseSessionTypeView(sessionContext: sessionContext)
             .tabItem {
-                createTabBarImage(plusImage)
+                createTabBarImage(tabSelection.getImageFor(.createSession))
             }
-            .tag(TabBarSelection.Tab.createSession)
+            .tag(TabBarSelector.Tab.createSession)
     }
     
     private var settingsTab: some View {
         SettingsView(sessionContext: sessionContext)
             .tabItem {
-                createTabBarImage(settingsImage)
+                createTabBarImage(tabSelection.getImageFor(.settings))
             }
-            .tag(TabBarSelection.Tab.settings)
+            .tag(TabBarSelector.Tab.settings)
     }
     
     private var reorderingButton: some View {
@@ -193,16 +186,6 @@ private extension MainTabBarView {
     }
 }
 
-class TabBarSelection: ObservableObject {
-    @Published var selection = Tab.dashboard
-    
-    enum Tab {
-        case dashboard
-        case createSession
-        case settings
-    }
-}
-
 class SelectedSection: ObservableObject {
     @Published var section = DashboardSection.following
     @Published var mobileSessionWasFinished = false
@@ -261,8 +244,8 @@ class ReorderButton: ObservableObject {
 }
 
 class SearchAndFollowButton: ObservableObject {
-     @Published var searchIsOn = false
-     @Published var isHidden = false
+    @Published var searchIsOn = false
+    @Published var isHidden = false
     
     func setHidden(if isActive: Bool) {
         if isActive {
@@ -270,44 +253,6 @@ class SearchAndFollowButton: ObservableObject {
         } else {
             withAnimation {
                 isHidden = false
-            }
-        }
-    }
- }
-
-extension MainTabBarView {
-    enum HomeIcon {
-        case selected
-        case unselected
-        
-        var string: String {
-            switch self {
-            case .selected: return Strings.MainTabBarView.homeBlueIcon
-            case .unselected: return Strings.MainTabBarView.homeIcon
-            }
-        }
-    }
-    
-    enum PlusIcon {
-        case selected
-        case unselected
-        
-        var string: String {
-            switch self {
-            case .selected: return Strings.MainTabBarView.plusBlueIcon
-            case .unselected: return Strings.MainTabBarView.plusIcon
-            }
-        }
-    }
-    
-    enum SettingsIcon {
-        case selected
-        case unselected
-        
-        var string: String {
-            switch self {
-            case .selected: return Strings.MainTabBarView.settingsBlueIcon
-            case .unselected: return Strings.MainTabBarView.settingsIcon
             }
         }
     }

--- a/AirCasting/TabBar/TabBarSelector.swift
+++ b/AirCasting/TabBar/TabBarSelector.swift
@@ -25,7 +25,7 @@ class TabBarSelector: ObservableObject {
                                 unselectedString: Strings.MainTabBarView.plusIcon)
     ]
     
-    func updateSelection(to newSelection: Tab) {
+    func update(to newSelection: Tab) {
         selection = newSelection
         
         if newSelection == .dashboard {

--- a/AirCasting/TabBar/TabBarSelector.swift
+++ b/AirCasting/TabBar/TabBarSelector.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Combine
+
+class TabBarSelector: ObservableObject {
+    enum Tab {
+        case dashboard
+        case createSession
+        case settings
+    }
+    
+    @Published private(set) var selection = Tab.dashboard {
+        didSet {
+            updateSelectedIcon()
+        }
+    }
+    
+    var dashboardSelectionNotifier = PassthroughSubject<Void, Never>()
+    private var tabBarIcons: [Tab: TabIcon] = [
+        .dashboard: TabIcon(state: .selected,
+                            selectedString: Strings.MainTabBarView.homeBlueIcon,
+                            unselectedString: Strings.MainTabBarView.homeIcon),
+        .settings: TabIcon(selectedString: Strings.MainTabBarView.settingsBlueIcon,
+                           unselectedString: Strings.MainTabBarView.settingsIcon),
+        .createSession: TabIcon(selectedString: Strings.MainTabBarView.plusBlueIcon,
+                                unselectedString: Strings.MainTabBarView.plusIcon)
+    ]
+    
+    func updateSelection(to newSelection: Tab) {
+        selection = newSelection
+        
+        if newSelection == .dashboard {
+            dashboardSelectionNotifier.send(())
+        }
+    }
+    
+    func getImageFor(_ tab: Tab) -> String {
+        guard let imageName = tabBarIcons[tab]?.imageName else { return "" }
+        return imageName
+    }
+    
+    private func updateSelectedIcon() {
+        tabBarIcons.keys.forEach { tab in
+            tabBarIcons[tab]?.state = (tab == selection) ? .selected : .unselected
+        }
+    }
+}
+
+extension TabBarSelector {
+    struct TabIcon {
+        enum TabIconState {
+            case selected
+            case unselected
+        }
+        
+        var imageName: String
+        var state: TabIconState {
+            didSet {
+                if state == .selected {
+                    imageName = selectedString
+                } else {
+                    imageName = unselectedString
+                }
+            }
+        }
+        
+        private let selectedString: String
+        private let unselectedString: String
+        
+        init(state: TabIconState = .unselected,
+             selectedString: String,
+             unselectedString: String) {
+            self.state = state
+            self.imageName = (state == .selected ? selectedString : unselectedString)
+            self.selectedString = selectedString
+            self.unselectedString = unselectedString
+        }
+    }
+}


### PR DESCRIPTION
1. TabBar selection is now managed by the new Entity - `TabBarSelector`
2. Icons are now transformed automatically after selection change
3. One place (SOT) of changing tabs
4. Improvements when the dashboard was tapped - deciding whether to go to `mobile active` of `following`
5. Home button works for map and graph now

https://trello.com/c/ey37Pwxv/867-home-button-doesnt-work-on-map-and-graph-screens