### PR TITLE
Creation screen - alignment fix

### DIFF
--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
@@ -238,13 +238,13 @@ struct ChooseSessionTypeView: View {
             let additionalSpace = max(height - minimalRequiredHeight, 0)
             let spacerHeight = min(additionalSpace / 2.0, 60)
             
-            VStack() {
+            VStack(alignment: .leading) {
                 Spacer().frame(height: spacerHeight)
                 VStack(alignment: .leading, spacing: 10) {
                     titleLabel
                     messageLabel
                 }
-                .padding(.horizontal)
+                .padding(.horizontal, 30)
                 Spacer().frame(height: spacerHeight)
                 VStack(alignment: .leading, spacing: 15) {
                     let horizontalSpacerRatio = 17.0
@@ -260,10 +260,11 @@ struct ChooseSessionTypeView: View {
                     }
                     let leftoverSpace = (additionalSpace - (spacerHeight * 2))
                     let innerSpacerHeight = min(leftoverSpace / 2, 25.0)
-                    Spacer().frame(height: innerSpacerHeight)
+                    Spacer().frame(height: innerSpacerHeight / 2)
                     if featureFlagsViewModel.enabledFeatures.contains(.sdCardSync) || featureFlagsViewModel.enabledFeatures.contains(.searchAndFollow) {
                         orLabel
                     }
+                    Spacer().frame(height: innerSpacerHeight / 2)
                     HStack {
                         switch (shouldShowSDSyncButton, shouldShowFollowSessionButton) {
                         case (false, true):
@@ -280,13 +281,13 @@ struct ChooseSessionTypeView: View {
                 }
                 .padding([.bottom, .vertical])
                 .padding(.horizontal, 30)
-                .background(Color.aircastingSecondaryBackground.ignoresSafeArea())
+                .background(Color.aircastingSecondaryBackground)
                 .alert(item: $viewModel.alert, content: { $0.makeAlert() })
             }
+            .background(Color.aircastingBackground.ignoresSafeArea())
             .onPreferenceChange(ViewHeightKey.self) {
                 self.buttonHeight = $0
             }
-            .background(Color.aircastingBackground.ignoresSafeArea())
         }
     }
 }
@@ -312,6 +313,8 @@ private extension ChooseSessionTypeView {
         Text(Strings.ChooseSessionTypeView.message)
             .font(Fonts.moderateRegularHeading1)
             .foregroundColor(.aircastingGray)
+            .minimumScaleFactor(0.8)
+            .lineLimit(1)
     }
     
     var recordNewLabel: some View {

--- a/AirCasting/MainTabBarView.swift
+++ b/AirCasting/MainTabBarView.swift
@@ -63,11 +63,11 @@ struct MainTabBarView: View {
             }
         }
         .onAppear {
-            UITabBar.appearance().backgroundColor = .aircastingBackground
             let appearance = UITabBarAppearance()
-            appearance.backgroundImage = UIImage()
+            appearance.backgroundColor = .aircastingBackground
             appearance.shadowImage = UIImage.mainTabBarShadow
             UITabBar.appearance().standardAppearance = appearance
+            UITabBar.appearance().scrollEdgeAppearance = appearance
             measurementsDownloadingInProgress = true
             measurementUpdatingService.updateAllSessionsMeasurements() {
                 DispatchQueue.main.async {

--- a/AirCasting/Utils/Strings.swift
+++ b/AirCasting/Utils/Strings.swift
@@ -683,10 +683,10 @@ struct Strings {
         static let orLabel: String = NSLocalizedString("or",
                                                        comment: "")
         
-        static let syncTitle: String = NSLocalizedString("Sync data storage if you recorded with AirBeam3 or AirBeam Mini",
+        static let syncTitle: String = NSLocalizedString("Sync storage if you recorded with AirBeam3 or AirBeam Mini",
                                                          comment: "")
         
-        static let syncData: String = NSLocalizedString("Sync data storage",
+        static let syncData: String = NSLocalizedString("Sync storage",
                                                                comment: "")
         static let followButtonTitle: String = NSLocalizedString("Follow session search & follow fixed sessions",
                                                                  comment: "")


### PR DESCRIPTION
TASKS:
- https://trello.com/c/E9M8SHBL/875-lets-begin-text-should-be-vertically-aligned-between-neighboring-rectangle-buttons
- https://trello.com/c/qLcbhKav/882-lets-begin-update-text

WHAT WAS DONE:
1. Removed code that did not affect the app
2. Improved TabBar, so it won't change its color when scrolled/when the background behind is changed
3. Aligned text on the creation screen