### PR TITLE
Measurements from AB mini should be recorded every second

### DIFF
--- a/AirCasting/AuthViews/UserSettings.swift
+++ b/AirCasting/AuthViews/UserSettings.swift
@@ -23,7 +23,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: crowdMapKey)
-            Log.info("Changed crowdMap contribution setting to \(contributingToCrowdMap ? "ON" : "OFF")")
+            Log.info("Changed crowdMap contribution setting to \(self.contributingToCrowdMap ? "ON" : "OFF")")
         }
     }
     
@@ -34,7 +34,7 @@ class UserSettings: ObservableObject {
         set {
             userDefaults.setValue(newValue, forKey: keepScreenOnKey)
             UIApplication.shared.isIdleTimerDisabled = userDefaults.bool(forKey: keepScreenOnKey)
-            Log.info("Changed keepScreenOn setting to \(keepScreenOn ? "ON" : "OFF")")
+            Log.info("Changed keepScreenOn setting to \(self.keepScreenOn ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }
@@ -45,7 +45,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: locationlessKey)
-            Log.info("Changed locationless sessions setting to \(disableMapping ? "ON" : "OFF")")
+            Log.info("Changed locationless sessions setting to \(self.disableMapping ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }
@@ -56,7 +56,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: convertToCelsiusKey)
-            Log.info("Changed convert to celcius setting to \(convertToCelsius ? "ON" : "OFF")")
+            Log.info("Changed convert to celcius setting to \(self.convertToCelsius ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }
@@ -67,7 +67,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: satteliteMapKey)
-            Log.info("Changed satellite setting to \(satteliteMap ? "ON" : "OFF")")
+            Log.info("Changed satellite setting to \(self.satteliteMap ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }
@@ -78,7 +78,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: twentyFourHourFormatKey)
-            Log.info("Changed twenty four hour format to \(twentyFourHour ? "ON" : "OFF")")
+            Log.info("Changed twenty four hour format to \(self.twentyFourHour ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }
@@ -89,7 +89,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: syncOnlyThroughWifiKey)
-            Log.info("Changed sync only through wifi to \(syncOnlyThroughWifi ? "ON" : "OFF")")
+            Log.info("Changed sync only through wifi to \(self.syncOnlyThroughWifi ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }
@@ -100,7 +100,7 @@ class UserSettings: ObservableObject {
         }
         set {
             userDefaults.setValue(newValue, forKey: dormantSessionsAlertKey)
-            Log.info("Changed dormant sessions alert to \(dormantSessionsAlert ? "ON" : "OFF")")
+            Log.info("Changed dormant sessions alert to \(self.dormantSessionsAlert ? "ON" : "OFF")")
             objectWillChange.send()
         }
     }

--- a/AirCasting/BluetoothSession/BluetoothSessionRecordingController.swift
+++ b/AirCasting/BluetoothSession/BluetoothSessionRecordingController.swift
@@ -111,7 +111,7 @@ class MobileAirBeamSessionRecordingController: BluetoothSessionRecordingControll
         isRecording = true
         measurementsSaver.changeStatusToRecording(for: activeSession.session.uuid)
         measurementsRecorder.record(with: activeSession.device) { [weak self] stream in
-            self?.measurementsSaver.handlePeripheralMeasurement(stream, sessionUUID: activeSession.session.uuid, locationless: activeSession.session.locationless)
+            self?.measurementsSaver.handlePeripheralMeasurement(stream, sessionUUID: activeSession.session.uuid, locationless: activeSession.session.locationless, device: activeSession.session.deviceType)
         }
     }
 }

--- a/AirCasting/BluetoothSession/BluetoothSessionRecordingController.swift
+++ b/AirCasting/BluetoothSession/BluetoothSessionRecordingController.swift
@@ -111,7 +111,7 @@ class MobileAirBeamSessionRecordingController: BluetoothSessionRecordingControll
         isRecording = true
         measurementsSaver.changeStatusToRecording(for: activeSession.session.uuid)
         measurementsRecorder.record(with: activeSession.device) { [weak self] stream in
-            self?.measurementsSaver.handlePeripheralMeasurement(stream, sessionUUID: activeSession.session.uuid, locationless: activeSession.session.locationless, device: activeSession.session.deviceType)
+            self?.measurementsSaver.handlePeripheralMeasurement(stream, sessionUUID: activeSession.session.uuid, locationless: activeSession.session.locationless)
         }
     }
 }

--- a/AirCasting/BluetoothSession/MeasurementsSavingService.swift
+++ b/AirCasting/BluetoothSession/MeasurementsSavingService.swift
@@ -57,7 +57,6 @@ class DefaultMeasurementsSaver: MeasurementsSavingService {
 
     func handlePeripheralMeasurement(_ measurement: ABMeasurementStream, sessionUUID: SessionUUID, locationless: Bool) {
         if peripheralMeasurementManager.collectedValuesCount == 5 { peripheralMeasurementManager.startNewValuesRound(locationless: locationless) }
-
         updateStreams(stream: measurement, sessionUUID: sessionUUID, location: peripheralMeasurementManager.currentLocation, time: peripheralMeasurementManager.currentTime)
         peripheralMeasurementManager.incrementCounter()
     }

--- a/AirCasting/BluetoothSession/MeasurementsSavingService.swift
+++ b/AirCasting/BluetoothSession/MeasurementsSavingService.swift
@@ -6,7 +6,7 @@ import Resolver
 import CoreLocation
 
 protocol MeasurementsSavingService {
-    func handlePeripheralMeasurement(_ measurement: ABMeasurementStream, sessionUUID: SessionUUID, locationless: Bool)
+    func handlePeripheralMeasurement(_ measurement: ABMeasurementStream, sessionUUID: SessionUUID, locationless: Bool, device: DeviceType?)
     func createSession(session: Session, device: any BluetoothDevice, completion: @escaping (Result<Void, Error>) -> Void)
     func changeStatusToRecording(for sessionUUID: SessionUUID)
 }
@@ -55,8 +55,21 @@ class DefaultMeasurementsSaver: MeasurementsSavingService {
         }
     }
 
-    func handlePeripheralMeasurement(_ measurement: ABMeasurementStream, sessionUUID: SessionUUID, locationless: Bool) {
-        if peripheralMeasurementManager.collectedValuesCount == 5 { peripheralMeasurementManager.startNewValuesRound(locationless: locationless) }
+    func handlePeripheralMeasurement(_ measurement: ABMeasurementStream, sessionUUID: SessionUUID, locationless: Bool, device: DeviceType?) {
+        let valuesCount: Int
+        switch device {
+        case .AIRBEAM3:
+            valuesCount = 5
+        case .AIRBEAMMINI:
+            valuesCount = 2
+        default:
+            valuesCount = 1
+            Log.warning("There's an unknown device recording session")
+        }
+        /* Explanation: We anticipate receiving 5 measurements from AirBeam 3 (AB3) and 2 from AirBeam Mini (AB2). It's crucial that these batches arrive with timestamps accurate to the second. Therefore, we wait for the expected number of measurements before updating streams with the current time. */
+        if peripheralMeasurementManager.collectedValuesCount == valuesCount {
+            peripheralMeasurementManager.startNewValuesRound(locationless: locationless)
+        }
         updateStreams(stream: measurement, sessionUUID: sessionUUID, location: peripheralMeasurementManager.currentLocation, time: peripheralMeasurementManager.currentTime)
         peripheralMeasurementManager.incrementCounter()
     }

--- a/AirCasting/CoreData/PersistenceController.swift
+++ b/AirCasting/CoreData/PersistenceController.swift
@@ -21,7 +21,7 @@ class PersistenceController: ObservableObject {
             }
         }
         didSet {
-            Log.info("UI updates \(uiSuspended ? "suspended" : "resumed")")
+            Log.info("UI updates \(self.uiSuspended ? "suspended" : "resumed")")
             
             if !uiSuspended {
                 propagateChangesToUI() {

--- a/AirCasting/CoreData/Session.swift
+++ b/AirCasting/CoreData/Session.swift
@@ -136,11 +136,13 @@ enum StreamingMethod: Int {
 public enum DeviceType: Int, CustomStringConvertible {
     case MIC = 0
     case AIRBEAM3 = 1
+    case AIRBEAMMINI = 2
 
     public var description: String {
         switch self {
         case .MIC: return "Device's Microphone"
         case .AIRBEAM3: return "AirBeam 3"
+        case .AIRBEAMMINI: return "AirBeamMini"
         }
     }
 }

--- a/AirCasting/FeatureFlags/FeatureFlagsViewModel.swift
+++ b/AirCasting/FeatureFlags/FeatureFlagsViewModel.swift
@@ -22,6 +22,6 @@ class FeatureFlagsViewModel: ObservableObject {
     
     private func updateList() {
         enabledFeatures = FeatureFlag.allCases.filter { provider.isFeatureOn($0) ?? false }
-        Log.info("Updated feature list: \(enabledFeatures)")
+        Log.info("Updated feature list: \(self.enabledFeatures)")
     }
 }

--- a/AirCasting/Map/LocationTracker.swift
+++ b/AirCasting/Map/LocationTracker.swift
@@ -50,7 +50,7 @@ final class CoreLocationTracker: NSObject, LocationTracker, LocationAuthorizatio
             locationManager.startUpdatingLocation()
         }
         locationStartReference += 1
-        Log.info("Started location tracking (refcount: \(locationStartReference))")
+        Log.info("Started location tracking (refcount: \(self.locationStartReference))")
         assert(locationStartReference >= 0)
     }
     
@@ -61,7 +61,7 @@ final class CoreLocationTracker: NSObject, LocationTracker, LocationAuthorizatio
             locationManager.stopUpdatingLocation()
             location.value = nil
         }
-        Log.info("Stopped location tracking (refcount: \(locationStartReference))")
+        Log.info("Stopped location tracking (refcount: \(self.locationStartReference))")
         assert(locationStartReference >= 0)
     }
     

--- a/AirCasting/SessionStopping/MicrophoneSessionStopper.swift
+++ b/AirCasting/SessionStopping/MicrophoneSessionStopper.swift
@@ -14,7 +14,7 @@ class MicrophoneSessionStopper: SessionStoppable {
     }
     
     func stopSession() throws {
-        Log.verbose("Stopping session with uuid \(uuid.rawValue) using microphone session stopper")
+        Log.verbose("Stopping session with uuid \(self.uuid.rawValue) using microphone session stopper")
         microphoneManager.stopRecording()
         sessionFinishingStorage.accessStorage { [self] storage in
             do {

--- a/AirCasting/SessionStopping/StandardSesssionStopper.swift
+++ b/AirCasting/SessionStopping/StandardSesssionStopper.swift
@@ -14,7 +14,7 @@ class StandardSesssionStopper: SessionStoppable {
     }
     
     func stopSession() {
-        Log.verbose("Stopping session with uuid \(uuid.rawValue) using standard session stopper")
+        Log.verbose("Stopping session with uuid \(self.uuid.rawValue) using standard session stopper")
         sessionRecorder.stopRecordingSession(with: uuid) {
             $0.accessStorage {
                 do {

--- a/AirCasting/SessionViews/ChartDatabaseObserver.swift
+++ b/AirCasting/SessionViews/ChartDatabaseObserver.swift
@@ -42,7 +42,7 @@ final class ChartDatabaseObserver {
                  "   New measurement time: \(newestMeasurement.time.debugInfo),\n" +
                  "   session name: \(newestMeasurement.measurementStream?.session?.name ?? newestMeasurement.measurementStream.externalSession?.name ?? "??")\n" +
                  "   session start time: \(newestMeasurement.measurementStream?.session?.startTime.debugInfo ?? newestMeasurement.measurementStream?.externalSession?.startTime.debugDescription ?? "no time"),\n" +
-                 "   filtering: \(filteringComponent)")
+                 "   filtering: \(self.filteringComponent)")
         onMeasurementsChange()
     }
     

--- a/AirCasting/SessionViews/ChartViewModel.swift
+++ b/AirCasting/SessionViews/ChartViewModel.swift
@@ -130,7 +130,7 @@ final class ChartViewModel: ObservableObject {
     // MARK: Debugging utils
     
     private func log(_ msg: String, level: LogLevel = .info, file: String = #fileID, function: String = #function, line: Int = #line) {
-        Log.log("\(msg). Session info: [\(logSessionInfo)]", type: level, file: file, function: function, line: line)
+        Log.log("\(msg). Session info: [\(self.logSessionInfo)]", type: level, file: file, function: function, line: line)
     }
     
     private var logSessionInfo: String {

--- a/AirCasting/SessionViews/ShareSession/ShareSessionViewModel.swift
+++ b/AirCasting/SessionViews/ShareSession/ShareSessionViewModel.swift
@@ -169,14 +169,14 @@ class DefaultShareSessionViewModel: ShareSessionViewModel {
         guard let sessionURL = session.urlLocation,
               var components = URLComponents(string: sessionURL)
         else {
-            Log.error("No URL for session \(String(describing: session.uuid))")
+            Log.error("No URL for session \(String(describing: self.session.uuid))")
             return
         }
         
         components.queryItems = [URLQueryItem(name: "sensor_name", value: selectedStream?.streamName)]
         
         guard let url = components.url else {
-            Log.error("Coudn't compose url for session \(String(describing: session.uuid))")
+            Log.error("Coudn't compose url for session \(String(describing: self.session.uuid))")
             return
         }
         

--- a/AirCasting/Utils/Logging/GarbageCollector/GarbageCollector.swift
+++ b/AirCasting/Utils/Logging/GarbageCollector/GarbageCollector.swift
@@ -18,7 +18,7 @@ class GarbageCollector {
     
     /// Adds a `DisposableDataHolder` to the list. Please note that this list references objects strongly. If you register a class type here, use a `WeakRef` wrapper.
     func addHolder(_ holder: DisposableDataHolder) {
-        Log.verbose("Added disposable data holder to garbage collection: \(printable(holder))")
+        Log.verbose("Added disposable data holder to garbage collection: \(self.printable(holder))")
         holders.append(holder)
     }
     

--- a/AirCasting/Utils/Microphone/Calibration/CalibratableMicrophoneDecorator.swift
+++ b/AirCasting/Utils/Microphone/Calibration/CalibratableMicrophoneDecorator.swift
@@ -13,7 +13,7 @@ class CalibratableMicrophoneDecorator: Microphone {
     
     init(microphone: Microphone) {
         self.microphone = microphone
-        Log.info("Initial zero dB level: \(calibrationValueProvider.zeroLevelAdjustment)")
+        Log.info("Initial zero dB level: \(self.calibrationValueProvider.zeroLevelAdjustment)")
     }
     
     func getCurrentDecibelLevel() -> Double? {

--- a/AppDelegate+Injection.swift
+++ b/AppDelegate+Injection.swift
@@ -183,6 +183,7 @@ extension Resolver: ResolverRegistering {
             switch session.deviceType {
             case .MIC: return MicrophoneSessionStopper(uuid: session.uuid)
             case .AIRBEAM3: return StandardSesssionStopper(uuid: session.uuid)
+            case .AIRBEAMMINI: return StandardSesssionStopper(uuid: session.uuid)
             case .none: return StandardSesssionStopper(uuid: session.uuid)
             }
         }


### PR DESCRIPTION
Long story short: Before, we used AB3 to record 5 streams together, waiting for all 5 measurements before timestamping. But with ABMini's 2 streams, timing got a bit off. Don't worry, it's fixed now! ;D 