### PR TITLE
fix: Fix for issues with syncing the data from ABMini standalone sessions

### DIFF
--- a/AirCasting/ABConnector/MeasurementsRecordingServices.swift
+++ b/AirCasting/ABConnector/MeasurementsRecordingServices.swift
@@ -21,14 +21,13 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
     
     private var miniMeasurementsCharacteristics: [String] = [
         "0000ffe4-0000-1000-8000-00805f9b34fb",    // PM1
-        "0000ffe5-0000-1000-8000-00805f9b34fb",    // PM2.5
-        ]    // Battery level
+        "0000ffe5-0000-1000-8000-00805f9b34fb"     // PM2.5
+        ]
     
     private var characteristicsObservers: [AnyHashable] = []
     
     func record(with device: any BluetoothDevice, completion: @escaping (ABMeasurementStream) -> Void) {
         do {
-            Log.warning("MARTA: record session run")
             let characteristics = device.airbeamType == .airBeamMini ? miniMeasurementsCharacteristics : measurementsCharacteristics
             try characteristics.forEach {
                 let observer = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: .init(value: $0)) { result in
@@ -53,8 +52,7 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
         characteristicsObservers.forEach({ bluetoothManager.unsubscribeCharacteristicObserver(token: $0)})
         characteristicsObservers = []
     }
-    
-    // TODO: This doesn't take battery lvl into consideration 
+
     private func parseData(data: Data) -> ABMeasurementStream? {
         let string = String(data: data, encoding: .utf8)
         let components = string?.components(separatedBy: ";")

--- a/AirCasting/ABConnector/MeasurementsRecordingServices.swift
+++ b/AirCasting/ABConnector/MeasurementsRecordingServices.swift
@@ -21,7 +21,8 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
     
     private var miniMeasurementsCharacteristics: [String] = [
         "0000ffe4-0000-1000-8000-00805f9b34fb",    // PM1
-        "0000ffe5-0000-1000-8000-00805f9b34fb"]    // PM2.5
+        "0000ffe5-0000-1000-8000-00805f9b34fb",    // PM2.5
+        ]    // Battery level
     
     private var characteristicsObservers: [AnyHashable] = []
     
@@ -29,7 +30,6 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
         do {
             let characteristics = device.airbeamType == .airBeamMini ? miniMeasurementsCharacteristics : measurementsCharacteristics
             try characteristics.forEach {
-                Log.warning("Łełołeło, troche problem. ")
                 let observer = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: .init(value: $0)) { result in
                     switch result {
                     case .success(let data):
@@ -53,6 +53,7 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
         characteristicsObservers = []
     }
     
+    // TODO: This doesn't take battery lvl into consideration 
     private func parseData(data: Data) -> ABMeasurementStream? {
         let string = String(data: data, encoding: .utf8)
         let components = string?.components(separatedBy: ";")

--- a/AirCasting/ABConnector/MeasurementsRecordingServices.swift
+++ b/AirCasting/ABConnector/MeasurementsRecordingServices.swift
@@ -28,6 +28,7 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
     
     func record(with device: any BluetoothDevice, completion: @escaping (ABMeasurementStream) -> Void) {
         do {
+            Log.warning("MARTA: record session run")
             let characteristics = device.airbeamType == .airBeamMini ? miniMeasurementsCharacteristics : measurementsCharacteristics
             try characteristics.forEach {
                 let observer = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: .init(value: $0)) { result in

--- a/AirCasting/ABConnector/MeasurementsRecordingServices.swift
+++ b/AirCasting/ABConnector/MeasurementsRecordingServices.swift
@@ -19,11 +19,17 @@ class AirbeamMeasurementsRecordingServices: MeasurementsRecordingServices {
         "0000ffe5-0000-1000-8000-00805f9b34fb",    // PM2.5
         "0000ffe6-0000-1000-8000-00805f9b34fb"]   // PM10
     
+    private var miniMeasurementsCharacteristics: [String] = [
+        "0000ffe4-0000-1000-8000-00805f9b34fb",    // PM1
+        "0000ffe5-0000-1000-8000-00805f9b34fb"]    // PM2.5
+    
     private var characteristicsObservers: [AnyHashable] = []
     
     func record(with device: any BluetoothDevice, completion: @escaping (ABMeasurementStream) -> Void) {
         do {
-            try measurementsCharacteristics.forEach {
+            let characteristics = device.airbeamType == .airBeamMini ? miniMeasurementsCharacteristics : measurementsCharacteristics
+            try characteristics.forEach {
+                Log.warning("Łełołeło, troche problem. ")
                 let observer = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: .init(value: $0)) { result in
                     switch result {
                     case .success(let data):

--- a/AirCasting/ABConnector/SDCardAirBeamServices.swift
+++ b/AirCasting/ABConnector/SDCardAirBeamServices.swift
@@ -112,17 +112,12 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
             metadataCharacteristicObserver = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID) { result in
                 switch result {
                 case .success(let data):
-                    Log.warning("MARTA: Metadata success outside queue")
                     self.queue.async { [weak self] in
-                        Log.warning("MARTA: Metadata success inside queue")
                         currentSessionType = currentSessionType.next
                         self?.handleMetadata(data, device: device, currentSessionType: currentSessionType!, completion: completion)
                     }
                 case .failure(let error):
-                    Log.warning("MARTA: Metadata failure outside queue")
                     self.queue.async { [weak self] in
-                        Log.warning("MARTA: Metadata failure inside queue")
-                        Log.warning("[SD SYNC]  Error while receiving metadata from SD card: \(error.localizedDescription)")
                         self?.finishSync(device: device) { completion(.failure(error)) }
                     }
                 }
@@ -131,16 +126,12 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
             dataCharacteristicObserver = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: DOWNLOAD_FROM_SD_CARD_CHARACTERISTIC_UUID) { result in
                 switch result {
                 case .success(let data):
-                    Log.warning("MARTA: Data success outside queue, data: \(String(describing: String(data: data!, encoding: .utf8)))")
+                    Log.warning("MARTA: data success outside queue, data: \(String(describing: String(data: data!, encoding: .utf8)))")
                     self.queue.async { [weak self] in
-                        Log.warning("MARTA: data success inside queue, data: \(String(describing: String(data: data!, encoding: .utf8)))")
                         self?.handlePayload(device: device, data: data, currentSessionType: currentSessionType, progress: progress, completion: completion)
                     }
                 case .failure(let error):
-                    Log.warning("MARTA: Data failure outside queue")
                     self.queue.async { [weak self] in
-                        Log.warning("MARTA: data failure inside queue")
-                        Log.warning("Error while receiving data from SD card: \(error.localizedDescription)")
                         self?.finishSync(device: device) { completion(.failure(error)) }
                     }
                 }

--- a/AirCasting/ABConnector/SDCardAirBeamServices.swift
+++ b/AirCasting/ABConnector/SDCardAirBeamServices.swift
@@ -108,29 +108,38 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
         var currentSessionType: SDCardSessionType?
         Log.info("[SD Sync] Downloading data")
         do {
+            Log.warning("Subscribe to bluettoth metadata with characteristics: \(self.DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID) ")
             metadataCharacteristicObserver = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID) { result in
                 switch result {
                 case .success(let data):
+                    Log.warning("MARTA: Metadata success outside queue")
                     self.queue.async { [weak self] in
+                        Log.warning("MARTA: Metadata success inside queue")
                         currentSessionType = currentSessionType.next
                         self?.handleMetadata(data, device: device, currentSessionType: currentSessionType!, completion: completion)
                     }
                 case .failure(let error):
+                    Log.warning("MARTA: Metadata failure outside queue")
                     self.queue.async { [weak self] in
+                        Log.warning("MARTA: Metadata failure inside queue")
                         Log.warning("[SD SYNC]  Error while receiving metadata from SD card: \(error.localizedDescription)")
                         self?.finishSync(device: device) { completion(.failure(error)) }
                     }
                 }
             }
-            
+            Log.warning("Subscribe to bluettoth data with characteristics: \(self.DOWNLOAD_FROM_SD_CARD_CHARACTERISTIC_UUID) ")
             dataCharacteristicObserver = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: DOWNLOAD_FROM_SD_CARD_CHARACTERISTIC_UUID) { result in
                 switch result {
                 case .success(let data):
+                    Log.warning("MARTA: Data success outside queue, data: \(String(describing: String(data: data!, encoding: .utf8)))")
                     self.queue.async { [weak self] in
+                        Log.warning("MARTA: data success inside queue, data: \(String(describing: String(data: data!, encoding: .utf8)))")
                         self?.handlePayload(device: device, data: data, currentSessionType: currentSessionType, progress: progress, completion: completion)
                     }
                 case .failure(let error):
+                    Log.warning("MARTA: Data failure outside queue")
                     self.queue.async { [weak self] in
+                        Log.warning("MARTA: data failure inside queue")
                         Log.warning("Error while receiving data from SD card: \(error.localizedDescription)")
                         self?.finishSync(device: device) { completion(.failure(error)) }
                     }
@@ -143,6 +152,7 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
     
     private func subscribeToMetaDataForClearingCard(device: any BluetoothDevice, completion: @escaping (Result<Void, Error>) -> Void) {
         do {
+            Log.warning("Subscribe to bluettoth clearing with characteristics: \(self.DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID) ")
             clearCardCharacteristicObserver = try bluetoothManager.subscribeToCharacteristic(for: device, characteristic: DOWNLOAD_META_DATA_FROM_SD_CARD_CHARACTERISTIC_UUID, timeout: 10) { result in
                 switch result {
                 case .success(let data):
@@ -177,7 +187,7 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
             return
         }
         
-        Log.info("[SD CARD SYNC] " + payload)
+        Log.info("[SD CARD SYNC] Metadata: " + payload)
         if payload == "SD_SYNC_FINISH" {
             // It is possible that when Airbeam is pluged in and the data is sent faster than iPhone can process, we receive this SD_SYNC_FINISH message before all of the payload is sent.
             // That's why we have to add the monitoring which checks if any new data is still being send, and if not, then we are letting the called know that Airbeam finished sending data.
@@ -210,13 +220,19 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
             self.finishSync(device: device) { completion(.failure(SDCardSyncError.wrongOrderOfReceivedPayload)) }
             return
         }
-        self.receivedMeasurementsCount[sessionType, default: 0] += Constants.SDCardSync.numberOfMeasurementsInDataChunk
+        
+        Log.warning("Handling payload \(payload) with measurenemts count ???")
+        let numberOfMeasurementsInChunk =  payload.components(separatedBy: "\r\n").filter { !$0.trimmingCharacters(in: ["\n"]).isEmpty }.count
+        /// It's not ALWAYS 4, right? What for smaller payloads?
+        self.receivedMeasurementsCount[sessionType, default: 0] += numberOfMeasurementsInChunk
         
         guard let expectedMeasurementsCount = self.expectedMeasurementsCount[sessionType], expectedMeasurementsCount != 0 else {
             Log.error("[SD SYNC] Received data for session type which should have 0 measurements")
             return
         }
         
+        
+        /// Why like this?
         let receivedMeasurementsNumber = self.receivedMeasurementsCount[sessionType]! < expectedMeasurementsCount ? self.receivedMeasurementsCount[sessionType]! : expectedMeasurementsCount
         let progressFraction = SDCardProgress(received: receivedMeasurementsNumber, expected: expectedMeasurementsCount)
         progress(SDCardDataChunk(payload: payload, sessionType: sessionType, progress: progressFraction))
@@ -249,7 +265,9 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
         
         var checkedMeasurementsCount: [SDCardSessionType: Int] = [:]
         monitoringForFinishedSendingToken = queue.schedule(after: queue.now, interval: .seconds(1)) {
-            Log.debug("Checking with:\n expected \(self.expectedMeasurementsCount)\n received \(self.receivedMeasurementsCount)\n checked \(checkedMeasurementsCount)")
+            
+            Log.debug("Checking measurements count with:\n expected \(self.expectedMeasurementsCount)\n received \(self.receivedMeasurementsCount)\n checked \(checkedMeasurementsCount)")
+            
             guard checkedMeasurementsCount != self.receivedMeasurementsCount else {
                 Log.debug("NO NEW MEASUREMENT IN 1 SEC")
                 completion()
@@ -264,7 +282,8 @@ class BluetoothSDCardAirBeamServices: SDCardAirBeamServices, BluetoothConnection
     }
     
     private func allMeasurementsDownloaded() -> Bool {
-        receivedMeasurementsCount.allSatisfy( { $1 >= expectedMeasurementsCount[$0] ?? 0 })
+        Log.warning("Monitoring for end of payload, expected: \(self.expectedMeasurementsCount), received: \(self.receivedMeasurementsCount)")
+        return receivedMeasurementsCount.allSatisfy( { $1 >= expectedMeasurementsCount[$0] ?? 0 })
     }
 }
 

--- a/AirCasting/SDSync/Parsing/MiniSDCardMeasurementsParser.swift
+++ b/AirCasting/SDSync/Parsing/MiniSDCardMeasurementsParser.swift
@@ -15,6 +15,7 @@ class MiniSDCardMeasurementsParser: SDMeasurementsParser {
         try lineReader.readLines(of: url) { result in
             switch result {
             case .line(let lineString):
+                // Reading from file
                 let measurementInfo = lineString.split(separator: ",")
                 if measurementInfo.count == firstLineColumns,
                    let uuidString = getUUID(lineString: lineString) {
@@ -68,14 +69,13 @@ class MiniSDCardMeasurementsParser: SDMeasurementsParser {
                                        time: measurementInfo[MiniSDCardCSVFileFactory.Header.time])
     }
     
-    func enumerateSessionLines(lines: [String], action: (String, String) -> Void) {
+    func enumerateSessionLines(lines: [String], action: (String?, String) -> Void) {
         var lastKnownUUID: String?
         lines.forEach { lineString in
             let measurementInfo = lineString.split(separator: ",")
             if measurementInfo.count == firstLineColumns {
                lastKnownUUID = getUUID(lineString: lineString)
             }
-            guard let lastKnownUUID else { return }
             action(lastKnownUUID, lineString)
         }
     }

--- a/AirCasting/SDSync/Parsing/MiniSDCardMeasurementsParser.swift
+++ b/AirCasting/SDSync/Parsing/MiniSDCardMeasurementsParser.swift
@@ -15,7 +15,6 @@ class MiniSDCardMeasurementsParser: SDMeasurementsParser {
         try lineReader.readLines(of: url) { result in
             switch result {
             case .line(let lineString):
-                // Reading from file
                 let measurementInfo = lineString.split(separator: ",")
                 if measurementInfo.count == firstLineColumns,
                    let uuidString = getUUID(lineString: lineString) {

--- a/AirCasting/SDSync/Parsing/SDCardMeasurementsParser.swift
+++ b/AirCasting/SDSync/Parsing/SDCardMeasurementsParser.swift
@@ -33,7 +33,7 @@ protocol SDMeasurementsParser {
     func getMeasurementTime(lineString: String) -> Date?
     func enumerateMeasurements(url: URL, action: (SDCardMeasurementsRow) -> Void) throws
     ///   - action: First argument is session ID. Second argument is line string.
-    func enumerateSessionLines(lines: [String], action: (String, String) -> Void)
+    func enumerateSessionLines(lines: [String], action: (String?, String) -> Void)
 }
 
 class SDCardMeasurementsParser: SDMeasurementsParser {
@@ -103,7 +103,7 @@ class SDCardMeasurementsParser: SDMeasurementsParser {
                                            time: measurementInfo[SDCardCSVFileFactory.Header.time.rawValue])
     }
     
-    func enumerateSessionLines(lines: [String], action: (String, String) -> Void) {
+    func enumerateSessionLines(lines: [String], action: (String?, String) -> Void) {
         lines.forEach { lineString in
             let uuid = getUUID(lineString: lineString)
             guard let uuid else { return }

--- a/AirCasting/SDSync/SDSyncFileWritingService.swift
+++ b/AirCasting/SDSync/SDSyncFileWritingService.swift
@@ -33,11 +33,19 @@ final class SDSyncFileWritingService: SDSyncFileWriter {
             }
         }
         
+        // Wszystkie linie? 
         let lines = data.components(separatedBy: "\r\n").filter { !$0.trimmingCharacters(in: ["\n"]).isEmpty }
+        let number = lines
         
         parser.enumerateSessionLines(lines: lines) { uuid, lineString in
-            let url = fileURL(for: sessionType, with: uuid)
-            currentURL = url
+            var url = currentURL
+            
+            if let uuid = uuid {
+                url = fileURL(for: sessionType, with: uuid)
+                currentURL = url
+            }
+            
+            guard let url else { return }
             buffers[url, default: []].append(lineString)
             let bufferCount = buffers[url]?.count ?? 0
             guard bufferCount == bufferThreshold else { return }

--- a/AirCasting/SDSync/SDSyncFileWritingService.swift
+++ b/AirCasting/SDSync/SDSyncFileWritingService.swift
@@ -33,13 +33,12 @@ final class SDSyncFileWritingService: SDSyncFileWriter {
             }
         }
         
-        // Wszystkie linie? 
         let lines = data.components(separatedBy: "\r\n").filter { !$0.trimmingCharacters(in: ["\n"]).isEmpty }
-        let number = lines
         
         parser.enumerateSessionLines(lines: lines) { uuid, lineString in
             var url = currentURL
             
+            // UUID can be nil when data comes from ABMini, in that case just keep using the current URL
             if let uuid = uuid {
                 url = fileURL(for: sessionType, with: uuid)
                 currentURL = url

--- a/AirCasting/Utils/Bluetooth/BluetoothManager.swift
+++ b/AirCasting/Utils/Bluetooth/BluetoothManager.swift
@@ -305,10 +305,8 @@ final class BluetoothManager: NSObject, BluetoothCommunicator, CBCentralManagerD
         characteristicsMappingLock.lock()
         charactieristicsMapping[characteristic, default:[]].append(observer)
         characteristicsMappingLock.unlock()
-        Log.warning("Device perihperal services: \(String(describing: device.peripheral.services))")
         device.peripheral.services?.forEach {
             let allMatching = $0.characteristics?.filter { $0.uuid == CBUUID(string: characteristic.value) } ?? []
-            Log.warning("All matching: \(allMatching)")
             allMatching.forEach {
                 device.peripheral.setNotifyValue(true, for: $0)
             }

--- a/AirCasting/Utils/Bluetooth/BluetoothManager.swift
+++ b/AirCasting/Utils/Bluetooth/BluetoothManager.swift
@@ -181,7 +181,6 @@ final class BluetoothManager: NSObject, BluetoothCommunicator, CBCentralManagerD
             
             DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
                 self.queue.async {
-                    Log.warning("MARTA: Number of connections for \(device.peripheral.identifier) is \(String(describing: self.connectionCallbacks[device.peripheral]))")
                     guard !(self.connectionCallbacks[device.peripheral]?.isEmpty ?? true) else {
                         return
                     }

--- a/AirCasting/Utils/Bluetooth/BluetoothManager.swift
+++ b/AirCasting/Utils/Bluetooth/BluetoothManager.swift
@@ -305,8 +305,10 @@ final class BluetoothManager: NSObject, BluetoothCommunicator, CBCentralManagerD
         characteristicsMappingLock.lock()
         charactieristicsMapping[characteristic, default:[]].append(observer)
         characteristicsMappingLock.unlock()
+        Log.warning("Device perihperal services: \(String(describing: device.peripheral.services))")
         device.peripheral.services?.forEach {
             let allMatching = $0.characteristics?.filter { $0.uuid == CBUUID(string: characteristic.value) } ?? []
+            Log.warning("All matching: \(allMatching)")
             allMatching.forEach {
                 device.peripheral.setNotifyValue(true, for: $0)
             }
@@ -376,7 +378,7 @@ final class BluetoothManager: NSObject, BluetoothCommunicator, CBCentralManagerD
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
         if error != nil {
-            Log.error("[SD Sync] \(error)")
+            Log.error("[SD Sync] \(String(describing: error))")
         }
     }
     

--- a/AirCasting/Utils/Bluetooth/BluetoothManager.swift
+++ b/AirCasting/Utils/Bluetooth/BluetoothManager.swift
@@ -181,6 +181,7 @@ final class BluetoothManager: NSObject, BluetoothCommunicator, CBCentralManagerD
             
             DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
                 self.queue.async {
+                    Log.warning("MARTA: Number of connections for \(device.peripheral.identifier) is \(String(describing: self.connectionCallbacks[device.peripheral]))")
                     guard !(self.connectionCallbacks[device.peripheral]?.isEmpty ?? true) else {
                         return
                     }
@@ -383,13 +384,14 @@ final class BluetoothManager: NSObject, BluetoothCommunicator, CBCentralManagerD
     }
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        let value = characteristic.value
         characteristicsMappingLock.lock()
         defer { characteristicsMappingLock.unlock()}
         guard let containgObserver = charactieristicsMapping.first(where: { CBUUID(string: $0.key.value) == characteristic.uuid }) else { return }
         containgObserver.value.forEach { observer in
             observer.triggerCounter += 1
             guard error == nil else { observer.action(.failure(error!)); return }
-            callbackQueue.async { observer.action(.success(characteristic.value)) }
+            callbackQueue.async { observer.action(.success(value)) }
         }
     }
     


### PR DESCRIPTION
This fixes the errors with ABmini standalone session sync. 

There were 3 main issues: 
- asking for wrong characteristics when setting up the sessions 
- not saving any data that didn't come in the first data chunk due to checking for UUID being present in each data chunk (for ABMini it is not) 
- race condition while accessing data from a peripheral that led to chunks being changed during function execution, and therefore to loosing/duplicationg some data. 

Also includes some cosmetic changes. 