### PR TITLE
fix: Remove mechanism for closing sheet - it was causing the update loop

### DIFF
--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
@@ -7,15 +7,16 @@ import AirCastingStyling
 struct CompleteScreen: View {
     @StateObject var viewModel: CompleteScreenViewModel
     
-    init(session: PartialExternalSession, exitRoute: @escaping () -> Void) {
-        _viewModel = .init(wrappedValue: CompleteScreenViewModel(session: session, exitRoute: exitRoute))
+    init(session: PartialExternalSession) {
+        _viewModel = .init(wrappedValue: CompleteScreenViewModel(session: session))
     }
     
     var body: some View {
+       // Text("ddd")
         sessionCard
             .overlay(
                 Button(action: {
-                    viewModel.xMarkTapped()
+                    //viewModel.xMarkTapped()
                 }, label: {
                     Image(systemName: "xmark")
                         .foregroundColor(.aircastingDarkGray)
@@ -175,7 +176,7 @@ private extension CompleteScreen {
 #if DEBUG
 struct CompleteScreen_Previews: PreviewProvider {
     static var previews: some View {
-        CompleteScreen(session: .mock, exitRoute: { })
+        CompleteScreen(session: .mock)
     }
 }
 #endif

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreen.swift
@@ -6,17 +6,17 @@ import AirCastingStyling
 
 struct CompleteScreen: View {
     @StateObject var viewModel: CompleteScreenViewModel
+    @Environment(\.dismiss) var dismiss
     
     init(session: PartialExternalSession) {
         _viewModel = .init(wrappedValue: CompleteScreenViewModel(session: session))
     }
     
     var body: some View {
-       // Text("ddd")
         sessionCard
             .overlay(
                 Button(action: {
-                    //viewModel.xMarkTapped()
+                    dismiss()
                 }, label: {
                     Image(systemName: "xmark")
                         .foregroundColor(.aircastingDarkGray)

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreenViewModel.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreenViewModel.swift
@@ -50,7 +50,6 @@ class CompleteScreenViewModel: ObservableObject {
     let sessionStartTime: Date
     let sessionEndTime: Date
     let sensorType: String
-    let exitRoute: () -> Void
     
     private var isOwnSession: Bool { userAuthenticationSession.user?.username == session.provider }
     private var session: PartialExternalSession
@@ -63,7 +62,7 @@ class CompleteScreenViewModel: ObservableObject {
     @Injected private var userAuthenticationSession: UserAuthenticationSession
     @Injected private var userSettings: UserSettings
     
-    init(session: PartialExternalSession, exitRoute: @escaping () -> Void) {
+    init(session: PartialExternalSession) {
         self.session = session
         sessionLongitude = session.longitude
         sessionLatitude = session.latitude
@@ -71,7 +70,6 @@ class CompleteScreenViewModel: ObservableObject {
         sessionStartTime = session.startTime
         sessionEndTime = session.endTime
         sensorType = session.provider
-        self.exitRoute = exitRoute
         refreshCompleteButtonText()
         reloadData()
         isSessionFollowed = externalSessionsStore.doesSessionExist(uuid: session.uuid)
@@ -95,10 +93,6 @@ class CompleteScreenViewModel: ObservableObject {
             assignValues(with: stream)
             generateChartEntires(with: stream)
         }
-    }
-    
-    func xMarkTapped() {
-        exitRoute()
     }
     
     func followButtonPressed() {
@@ -170,7 +164,7 @@ class CompleteScreenViewModel: ObservableObject {
     }
     
     private func dismissView() {
-        exitRoute()
+        //exitRoute()
     }
     
     private func refresh() {

--- a/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreenViewModel.swift
+++ b/AirCasting/SearchAndFollow/CompleteScreen/Views/CompleteScreenViewModel.swift
@@ -163,10 +163,6 @@ class CompleteScreenViewModel: ObservableObject {
         }
     }
     
-    private func dismissView() {
-        //exitRoute()
-    }
-    
     private func refresh() {
         streamsDownloader.downloadStreams(with: session.id) { result in
             switch result {
@@ -247,7 +243,7 @@ class CompleteScreenViewModel: ObservableObject {
     
     private func showAlert() {
         DispatchQueue.main.async {
-            self.alert = InAppAlerts.failedSessionDownloadAlert(dismiss: self.dismissView)
+            self.alert = InAppAlerts.failedSessionDownloadAlert(dismiss: {} )
         }
     }
     

--- a/AirCasting/SearchAndFollow/SearchAndFollowMap/SearchAndFollowMap.swift
+++ b/AirCasting/SearchAndFollow/SearchAndFollowMap/SearchAndFollowMap.swift
@@ -47,7 +47,6 @@ struct SearchAndFollowMap: UIViewRepresentable {
     }
     
     func makeUIView(context: Context) -> GMSMapView {
-        //GMSServices.provideAPIKey(GOOGLE_MAP_KEY)
         context.coordinator.startingPointHolder = self.startingPoint
         let startingPoint = setStartingPoint(using: startingPoint)
         let mapView = GMSMapView.map(withFrame: .zero,

--- a/AirCasting/SearchAndFollow/SearchAndFollowMap/SearchAndFollowMap.swift
+++ b/AirCasting/SearchAndFollow/SearchAndFollowMap/SearchAndFollowMap.swift
@@ -47,7 +47,7 @@ struct SearchAndFollowMap: UIViewRepresentable {
     }
     
     func makeUIView(context: Context) -> GMSMapView {
-        GMSServices.provideAPIKey(GOOGLE_MAP_KEY)
+        //GMSServices.provideAPIKey(GOOGLE_MAP_KEY)
         context.coordinator.startingPointHolder = self.startingPoint
         let startingPoint = setStartingPoint(using: startingPoint)
         let mapView = GMSMapView.map(withFrame: .zero,

--- a/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 struct BottomCardView: View {
     @StateObject var viewModel: BottomCardViewModel
+    @State var sheetIsPresented = false
     private var onMarkerChangeAction: ((Int) -> ())? = nil
     
     init(session: PartialExternalSession) {
@@ -18,8 +19,8 @@ struct BottomCardView: View {
     
     var sessionCard: some View {
         Button {
-            viewModel.sessionCardTapped()
-            onMarkerChangeAction?(viewModel.dataModel.id)
+            sheetIsPresented = true
+            //onMarkerChangeAction?(viewModel.dataModel.id)
         } label: {
             VStack(alignment: .leading, spacing: 5) {
                 Text(viewModel.dataModel.title)
@@ -36,11 +37,9 @@ struct BottomCardView: View {
                     .scaledToFit()
             }
         }
-        .sheet(isPresented: .init(get: {
-            viewModel.getIsModalScreenPresented()
-        }, set: { value in
-            viewModel.setIsModalScreenPresented(using: value)
-        }), content: { viewModel.initCompleteScreen() })
+        .sheet(isPresented: $sheetIsPresented){
+            viewModel.initCompleteScreen()
+        }
         .frame(width: 200, alignment: .leading)
         .padding(10)
         .background(Color.aircastingBackground)

--- a/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
@@ -20,7 +20,7 @@ struct BottomCardView: View {
     var sessionCard: some View {
         Button {
             sheetIsPresented = true
-            //onMarkerChangeAction?(viewModel.dataModel.id)
+            onMarkerChangeAction?(viewModel.dataModel.id)
         } label: {
             VStack(alignment: .leading, spacing: 5) {
                 Text(viewModel.dataModel.title)

--- a/AirCasting/SearchAndFollow/SearchMap/BottomCardViewModel.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCardViewModel.swift
@@ -6,20 +6,12 @@ import SwiftUI
 import Resolver
 
 class BottomCardViewModel: ObservableObject {
-    @Published private var isModalScreenPresented = false
     let dataModel: BottomCardModel
     let session: PartialExternalSession
     
     init(session: PartialExternalSession) {
         dataModel = .init(id: session.id, title: session.name, startTime: session.startTime, endTime: session.endTime)
         self.session = session
-    }
-    
-    func getIsModalScreenPresented() -> Bool { isModalScreenPresented }
-    func setIsModalScreenPresented(using v: Bool) { DispatchQueue.main.async { self.isModalScreenPresented = v } }
-    
-    func sessionCardTapped() {
-        setIsModalScreenPresented(using: true)
     }
     
     func adaptTimeAndDate() -> String {
@@ -31,8 +23,6 @@ class BottomCardViewModel: ObservableObject {
     }
     
     func initCompleteScreen() -> CompleteScreen {
-        CompleteScreen(session: session) { [weak self] in
-            self?.isModalScreenPresented = false
-        }
+        CompleteScreen(session: session)
     }
 }


### PR DESCRIPTION
Using exit route on CompleteScreen led to a loop of updateUIView function in SearchAndFollowMap being run again and again on iOS18. 

Refactored to an easier solution of sheet dismissing itself. 