### PR TITLE
fix: Change sheet to fullscreenCover to avoid looped UI updates

### DIFF
--- a/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
+++ b/AirCasting/SearchAndFollow/SearchMap/BottomCard.swift
@@ -37,7 +37,7 @@ struct BottomCardView: View {
                     .scaledToFit()
             }
         }
-        .sheet(isPresented: $sheetIsPresented){
+        .fullScreenCover(isPresented: $sheetIsPresented){
             viewModel.initCompleteScreen()
         }
         .frame(width: 200, alignment: .leading)


### PR DESCRIPTION
This is not a full solution, this is a band-aid but an effective one. 

So, we have a problem. Starting iOS 18 when presenting sheet on BottomCard - the app freezes. After investigation I learned that is is stuck in a constant UI update cycle between SearchAndFollowMap, SearchMap, SearchView going up to Dashboard view, which I think bacisally means that the whole UI is being redrawn underneath. I suspect some data being updated on a loop and I've been trying to find a binding that is causing it - without any luck. You can find remnants of that on mpanuszewska/sheet_debugging branch. 
The issue has nothing to do with what is presented inside this sheet, as even presenting an empty sheet leads to this freese.

Anyway, presenting this view as a full screen cover solved the issue. I'm not sure if it's because it just stops UI refresh underneath or if the issue lies in the sheet component itself. The issue clearly started with iOS18 so we should figure out if it is caused by change in the sensitivity of UI refresh, of data bindings or in something in the implementation of the sheet component.