### PR TITLE
fix/unnecessary-create-mobile-requests-sd-sync-unfinished-session

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		339AC2902934DEBE0083D8FF /* SessionNotesStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339AC28F2934DEBE0083D8FF /* SessionNotesStorage.swift */; };
 		339BF3E127D231F000BBCB23 /* StaticSessionHeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339BF3E027D231F000BBCB23 /* StaticSessionHeaderViewModel.swift */; };
 		339E1A24292F9A7D003910A5 /* UserTriggeredReconnectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339E1A23292F9A7D003910A5 /* UserTriggeredReconnectionController.swift */; };
+		33A16E7B2DF6F76400D9142A /* Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A16E7A2DF6F76400D9142A /* Concurrency.swift */; };
 		33A7FF1A27C5115700A138D6 /* CompleteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A7FF1927C5115700A138D6 /* CompleteScreen.swift */; };
 		33A7FF1D27C511A200A138D6 /* CompleteScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A7FF1C27C511A200A138D6 /* CompleteScreenViewModel.swift */; };
 		33A7FF2127C5160A00A138D6 /* StaticSessionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A7FF2027C5160A00A138D6 /* StaticSessionHeader.swift */; };
@@ -690,6 +691,7 @@
 		339AC28F2934DEBE0083D8FF /* SessionNotesStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNotesStorage.swift; sourceTree = "<group>"; };
 		339BF3E027D231F000BBCB23 /* StaticSessionHeaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticSessionHeaderViewModel.swift; sourceTree = "<group>"; };
 		339E1A23292F9A7D003910A5 /* UserTriggeredReconnectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTriggeredReconnectionController.swift; sourceTree = "<group>"; };
+		33A16E7A2DF6F76400D9142A /* Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Concurrency.swift; sourceTree = "<group>"; };
 		33A7FF1927C5115700A138D6 /* CompleteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteScreen.swift; sourceTree = "<group>"; };
 		33A7FF1C27C511A200A138D6 /* CompleteScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteScreenViewModel.swift; sourceTree = "<group>"; };
 		33A7FF2027C5160A00A138D6 /* StaticSessionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticSessionHeader.swift; sourceTree = "<group>"; };
@@ -1683,6 +1685,7 @@
 				33B397D8284FB77400C95387 /* PhotoPicker.swift */,
 				33F87610286343D70073A3D4 /* DownloadableImage.swift */,
 				ACBF1AD1286C618F006DF793 /* XMarkButton.swift */,
+				33A16E7A2DF6F76400D9142A /* Concurrency.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3552,6 +3555,7 @@
 				33F96EA8293E7F4F00FE7F0A /* BluetoothDevice.swift in Sources */,
 				335B54BF28BD01C300BA92D2 /* CustomSwipeAction.swift in Sources */,
 				FA4F1B75281809B2002711B4 /* AirBeamStreamSuffixes.swift in Sources */,
+				33A16E7B2DF6F76400D9142A /* Concurrency.swift in Sources */,
 				B3ED03C32729A8E300513522 /* AirCastingNotifications.swift in Sources */,
 				AC006D2B275F537300E99019 /* UploadFixedSessionAPIService.swift in Sources */,
 				33831B19291549A60097020C /* BluetoothSessionRecordingController.swift in Sources */,

--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A4CB0BCB65AE32375CEBE95 /* Pods_AirCastingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AFCF31E099030C84C1A23F9 /* Pods_AirCastingTests.framework */; };
 		33050871276B568D00D18C69 /* ShareSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33050870276B568D00D18C69 /* ShareSessionViewModel.swift */; };
 		33050876276B7A4400D18C69 /* ShareSessionStreamOptionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33050875276B7A4400D18C69 /* ShareSessionStreamOptionViewModel.swift */; };
+		33056A812DF0773F0087FA75 /* SDCardMobileSessionFinisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33056A802DF0773F0087FA75 /* SDCardMobileSessionFinisher.swift */; };
 		331D32D528328A92001A6414 /* Sessionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331D32D428328A92001A6414 /* Sessionable.swift */; };
 		331EA80A25E32094009DEFDB /* ConfirmCreatingSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331EA80925E32094009DEFDB /* ConfirmCreatingSessionView.swift */; };
 		332020A6283CF6D1003E07F3 /* ExternalSessionEntity+Sessionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332020A5283CF6D1003E07F3 /* ExternalSessionEntity+Sessionable.swift */; };
@@ -603,6 +604,7 @@
 /* Begin PBXFileReference section */
 		33050870276B568D00D18C69 /* ShareSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSessionViewModel.swift; sourceTree = "<group>"; };
 		33050875276B7A4400D18C69 /* ShareSessionStreamOptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSessionStreamOptionViewModel.swift; sourceTree = "<group>"; };
+		33056A802DF0773F0087FA75 /* SDCardMobileSessionFinisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDCardMobileSessionFinisher.swift; sourceTree = "<group>"; };
 		331D32D428328A92001A6414 /* Sessionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sessionable.swift; sourceTree = "<group>"; };
 		331EA80925E32094009DEFDB /* ConfirmCreatingSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmCreatingSessionView.swift; sourceTree = "<group>"; };
 		332020A5283CF6D1003E07F3 /* ExternalSessionEntity+Sessionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExternalSessionEntity+Sessionable.swift"; sourceTree = "<group>"; };
@@ -2004,6 +2006,7 @@
 			children = (
 				334CC6F92751454C00C10B53 /* SDCardMobileSessionsSavingService.swift */,
 				334EF27D28E5CE7E000DD51E /* SDSyncMobileSessionStorage.swift */,
+				33056A802DF0773F0087FA75 /* SDCardMobileSessionFinisher.swift */,
 			);
 			path = MobileSessions;
 			sourceTree = "<group>";
@@ -3219,9 +3222,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirCasting/Pods-AirCasting-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirCasting/Pods-AirCasting-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3236,9 +3243,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirCasting/Pods-AirCasting-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AirCasting/Pods-AirCasting-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3395,6 +3406,7 @@
 				B3F1447426ADF8A7006A4612 /* ScheduledTimer.swift in Sources */,
 				B30BAC042694A8B400AE0476 /* MapStatsDataSource.swift in Sources */,
 				332066AC2898156D00798AC1 /* ThresholdAlertSheet.swift in Sources */,
+				33056A812DF0773F0087FA75 /* SDCardMobileSessionFinisher.swift in Sources */,
 				AC9EB64526ECB11B00B1F780 /* DefaultSyncingMeasurementsViewModel.swift in Sources */,
 				B30BAC1D2694AABC00AE0476 /* MeasurementStatisticsTypes.swift in Sources */,
 				B32D08AF267A6D13006C97ED /* ErasingToVoidPublisher.swift in Sources */,

--- a/AirCasting/SDSync/MobileSessions/SDCardMobileSessionFinisher.swift
+++ b/AirCasting/SDSync/MobileSessions/SDCardMobileSessionFinisher.swift
@@ -1,0 +1,26 @@
+// Created by Lunar on 4.06.25.
+//
+
+import Foundation
+import Resolver
+import CoreData
+
+
+protocol SessionFinisher {
+    func callAsFunction(uuid: SessionUUID) throws
+}
+
+class SDCardMobileSessionFinisher : SessionFinisher {
+    @Injected private var persistenceController: PersistenceController
+    private lazy var context: NSManagedObjectContext = persistenceController.editContext
+    
+    func callAsFunction(uuid: SessionUUID) throws {
+        let sessionEntity = try context.existingSession(uuid: uuid)
+        if (sessionEntity.isInStandaloneMode) {
+            sessionEntity.status = .FINISHED
+            guard let endTime = sessionEntity.lastMeasurementTime else { return }
+            Log.info("SD Sync end time for session (UUID | name) \(sessionEntity.uuid) \(sessionEntity.name ?? ""): \(endTime)")
+            sessionEntity.endTime = endTime
+        }
+    }
+}

--- a/AirCasting/SDSync/MobileSessions/SDCardMobileSessionFinisher.swift
+++ b/AirCasting/SDSync/MobileSessions/SDCardMobileSessionFinisher.swift
@@ -16,11 +16,12 @@ class SDCardMobileSessionFinisher : SessionFinisher {
     
     func callAsFunction(uuid: SessionUUID) throws {
         let sessionEntity = try context.existingSession(uuid: uuid)
-        if (sessionEntity.isInStandaloneMode) {
-            sessionEntity.status = .FINISHED
-            guard let endTime = sessionEntity.lastMeasurementTime else { return }
-            Log.info("SD Sync end time for session (UUID | name) \(sessionEntity.uuid) \(sessionEntity.name ?? ""): \(endTime)")
-            sessionEntity.endTime = endTime
-        }
+        
+        guard sessionEntity.isInStandaloneMode else { Log.info("SD Sync tried finish \(uuid) which is not in standalone mode!"); return }
+        
+        sessionEntity.status = .FINISHED
+        guard let endTime = sessionEntity.lastMeasurementTime else { return }
+        Log.info("SD Sync measurement end time for session (UUID | name) \(sessionEntity.uuid) \(sessionEntity.name ?? ""): \(endTime)")
+        sessionEntity.endTime = endTime
     }
 }

--- a/AirCasting/SDSync/MobileSessions/SDCardMobileSessionsSavingService.swift
+++ b/AirCasting/SDSync/MobileSessions/SDCardMobileSessionsSavingService.swift
@@ -36,7 +36,7 @@ class SDCardMobileSessionsSavingService: SDCardMobileSessionssSaver {
     @Injected private var fileLineReader: FileLineReader
     @Injected private var averagingService: MeasurementsAveragingService
     @Injected private var persistenceController: PersistenceController
-    private var databaseStorage = SDSyncMobileSessionsDatabaseStorage()
+    @Injected private var databaseStorage: SDSyncMobileSessionsDatabaseStorage
     private lazy var context: NSManagedObjectContext = persistenceController.editContext
     private var sessionUUID: SessionUUID?
     private var location: CLLocationCoordinate2D? = nil
@@ -165,7 +165,6 @@ class SDCardMobileSessionsSavingService: SDCardMobileSessionssSaver {
                 do {
                     try self.saveData(streamsWithMeasurements, session: &sessionData)
                     try self.averageUnaveragedMeasurements(sessionUUID: sessionData.uuid, averagingWindow: sessionData.averaging ?? .zeroWindow)
-                    try self.databaseStorage.setStatusToFinishedAndUpdateEndTime(for: sessionData.uuid, context: self.context)
                     try self.context.save()
                     completion(.success(()))
                 } catch {

--- a/AirCasting/SDSync/MobileSessions/SDCardMobileSessionsSavingService.swift
+++ b/AirCasting/SDSync/MobileSessions/SDCardMobileSessionsSavingService.swift
@@ -166,6 +166,7 @@ class SDCardMobileSessionsSavingService: SDCardMobileSessionssSaver {
                     try self.saveData(streamsWithMeasurements, session: &sessionData)
                     try self.averageUnaveragedMeasurements(sessionUUID: sessionData.uuid, averagingWindow: sessionData.averaging ?? .zeroWindow)
                     try self.context.save()
+                    
                     completion(.success(()))
                 } catch {
                     completion(.failure(error))

--- a/AirCasting/SDSync/MobileSessions/SDSyncMobileSessionStorage.swift
+++ b/AirCasting/SDSync/MobileSessions/SDSyncMobileSessionStorage.swift
@@ -18,14 +18,6 @@ struct SDSyncMobileSessionsDatabaseStorage {
         stream.addToMeasurements(newMeasurement)
     }
     
-    func setStatusToFinishedAndUpdateEndTime(for sessionUUID: SessionUUID, context: NSManagedObjectContext) throws {
-        let sessionEntity = try context.existingSession(uuid: sessionUUID)
-        sessionEntity.status = .FINISHED
-        guard let endTime = sessionEntity.lastMeasurementTime else { return }
-        Log.info("SD Sync end time for session (UUID | name) \(sessionEntity.uuid) \(sessionEntity.name ?? ""): \(endTime)")
-        sessionEntity.endTime = endTime
-    }
-    
     func fetchUnaveragedMeasurements(currentWindow: AveragingWindow, stream: MeasurementStreamEntity, context: NSManagedObjectContext) throws -> [MeasurementEntity] {
         let fetchRequest = fetchRequestForUnaveragedMeasurements(currentWindow: currentWindow, stream: stream)
         return try context.fetch(fetchRequest)

--- a/AirCasting/SDSync/SDSyncController.swift
+++ b/AirCasting/SDSync/SDSyncController.swift
@@ -42,6 +42,8 @@ class SDSyncController {
     @Injected private var sessionSynchronizer: SessionSynchronizer
     @Injected private var measurementsDownloader: SyncedMeasurementsDownloader
     @Injected private var locationTracker: LocationTracker
+    @Injected private var databaseStorage: SDSyncMobileSessionsDatabaseStorage
+    @Injected private var finishStandaloneSession: SessionFinisher
     
     private let writingQueue = DispatchQueue(label: "SDSyncController")
     
@@ -137,6 +139,8 @@ class SDSyncController {
             Log.info("[SD Sync] Completion success. There were no directories.")
             completion(.success(()))
         }
+        // TODO: finish the triggering mobile session
+        
     }
     
     private func process(fixedSessionsFilesDirectory: URL, deviceID: String, completion: @escaping (Result<[SessionUUID], Error>) -> Void) {

--- a/AirCasting/SDSync/SDSyncController.swift
+++ b/AirCasting/SDSync/SDSyncController.swift
@@ -46,9 +46,16 @@ class SDSyncController {
     @Injected private var finishStandaloneSession: SessionFinisher
     
     private let writingQueue = DispatchQueue(label: "SDSyncController")
+    private var standaloneSessionToSyncAndFinish: StandaloneSessionToSyncAndFinish?
     
-    func syncFromAirbeam(_ airbeamConnection: any BluetoothDevice, progress: @escaping (SDCardSyncStatus) -> Void, completion: @escaping (Result<Void, SDSyncError>) -> Void) {
+    func syncFromAirbeam(standaloneSessionToSyncAndFinish: StandaloneSessionToSyncAndFinish,
+                         _ airbeamConnection: any BluetoothDevice,
+                         progress: @escaping (SDCardSyncStatus) -> Void,
+                         completion: @escaping (Result<Void, SDSyncError>) -> Void) {
         Log.info("[SD SYNC] Starting syncing")
+        
+        self.standaloneSessionToSyncAndFinish = standaloneSessionToSyncAndFinish
+        
         guard let sensorName = airbeamConnection.name,
               let airbeamType = airbeamConnection.airbeamType else {
             Log.error("[SD SYNC] Unable to identify the device")
@@ -76,6 +83,12 @@ class SDSyncController {
                     Log.info("[SD SYNC] Files: \(directories)")
                     guard !directories.isEmpty else {
                         Log.info("[SD SYNC] No files. Finishing sd sync")
+                        do {
+                            try self.finishStandaloneSessionIfPresent(completion)
+                        } catch {
+                            completion(.failure(.mobileSessionsProcessingFailure))
+                            return
+                        }
                         completion(.success(()))
                         return
                     }
@@ -87,7 +100,9 @@ class SDSyncController {
                         switch fileValidationResult {
                         case .success(let verifiedDirectories):
                             Log.info("[SD SYNC] Check for corruption passed")
-                            self.handle(filesDirectories: verifiedDirectories, sensorName: sensorName, completion: completion)
+                            self.handle(filesDirectories: verifiedDirectories,
+                                        sensorName: sensorName,
+                                        completion: completion)
                         case .failure(let error):
                             Log.error(error.localizedDescription)
                             completion(.failure(.filesCorrupted))
@@ -102,7 +117,17 @@ class SDSyncController {
         })
     }
     
-    private func handle(filesDirectories: [(URL, SDCardSessionType)], sensorName: String, completion: @escaping (Result<Void, SDSyncError>) -> Void ) {
+    fileprivate func finishStandaloneSessionIfPresent(_ completion: (Result<Void, SDSyncError>) -> Void) throws {
+        if let uuidOfSessionToFinish = standaloneSessionToSyncAndFinish?.uuid {
+            try finishStandaloneSession(uuid: uuidOfSessionToFinish)
+            standaloneSessionToSyncAndFinish?.clearSessionUuid()
+        } else { Log.info("[SD Sync] There was no standalone session to finish.") }
+        self.onCurrentSyncEnd { self.startBackendSync() }
+    }
+    
+    private func handle(filesDirectories: [(URL, SDCardSessionType)],
+                        sensorName: String,
+                        completion: @escaping (Result<Void, SDSyncError>) -> Void) {
         let mobileFilesDirectoryURL = filesDirectories.first(where: { $0.1 == SDCardSessionType.mobile })?.0
         let fixedFilesDirectoryURL = filesDirectories.first(where: { $0.1 == SDCardSessionType.fixed })?.0
         
@@ -125,22 +150,22 @@ class SDSyncController {
                     completion(.failure(.mobileSessionsProcessingFailure))
                     return
                 }
-                
-                if let fixedFilesDirectoryURL = fixedFilesDirectoryURL {
-                    handleFixedFiles(at: fixedFilesDirectoryURL)
-                } else {
-                    Log.info("[SD Sync] Completion success. There was no fixed directory.")
-                    completion(.success(()))
-                }
             }
-        } else if let fixedFilesDirectoryURL = fixedFilesDirectoryURL {
-            handleFixedFiles(at: fixedFilesDirectoryURL)
-        } else {
-            Log.info("[SD Sync] Completion success. There were no directories.")
-            completion(.success(()))
-        }
-        // TODO: finish the triggering mobile session
+        } else { Log.info("[SD Sync] There was no mobile directory.") }
         
+        if let fixedFilesDirectoryURL = fixedFilesDirectoryURL {
+            handleFixedFiles(at: fixedFilesDirectoryURL)
+        } else { Log.info("[SD Sync] There was no fixed directory.") }
+        
+        do {
+            try finishStandaloneSessionIfPresent(completion)
+        } catch {
+            completion(.failure(.mobileSessionsProcessingFailure))
+            return
+        }
+        
+        Log.info("[SD Sync] Completion success.")
+        completion(.success(()))
     }
     
     private func process(fixedSessionsFilesDirectory: URL, deviceID: String, completion: @escaping (Result<[SessionUUID], Error>) -> Void) {
@@ -165,7 +190,6 @@ class SDSyncController {
                 switch result {
                 case .success():
                     Log.info("[SD Sync] Saved mobile data with success")
-                    self.onCurrentSyncEnd { self.startBackendSync() }
                     completion(true)
                 case .failure(let error):
                     Log.error("[SD Sync] Failed to save sessions to database: \(error.localizedDescription)")

--- a/AirCasting/SDSync/SDSyncController.swift
+++ b/AirCasting/SDSync/SDSyncController.swift
@@ -62,7 +62,7 @@ class SDSyncController {
             completion(.failure(.unidetifiableDevice))
             return
         }
-
+        
         airbeamServices.downloadData(from: airbeamConnection, progress: { [weak self] chunk in
             // Filesystem write
             let parser = Resolver.resolve(SDMeasurementsParser.self, args: sensorName)
@@ -95,7 +95,7 @@ class SDSyncController {
                     
                     // MARK: checking if files have the right number of rows and if rows have the right values
                     
-                    let fileValidator = Resolver.resolve(SDSyncFileValidator.self, args: airbeamType) 
+                    let fileValidator = Resolver.resolve(SDSyncFileValidator.self, args: airbeamType)
                     self.checkDirectoriesForCorruption(directories, expectedMeasurementsCount: metadata.expectedMeasurementsCount, fileValidator: fileValidator) { fileValidationResult in
                         switch fileValidationResult {
                         case .success(let verifiedDirectories):
@@ -184,8 +184,10 @@ class SDSyncController {
     
     private func process(mobileSessionFilesDirectory: URL, deviceID: String, completion: @escaping (Bool) -> Void) {
         Log.info("[SD Sync] Processing mobile file")
-        Task {
-            let location = try await locationTracker.oneTimeLocationUpdate()
+        
+        do {
+            let location = try waitFor(locationTracker.oneTimeLocationUpdate)
+            
             self.mobileSessionsSaver.saveDataToDb(filesDirectoryURL: mobileSessionFilesDirectory, deviceID: deviceID, deviceLocation: .init(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)) { result in
                 switch result {
                 case .success():
@@ -196,7 +198,11 @@ class SDSyncController {
                     completion(false)
                 }
             }
+        } catch {
+            Log.error("[SD Sync] Failed retrieve location: \(error.localizedDescription)")
+            completion(false)
         }
+        
     }
     
     func clearSDCard(_ airbeamConnection: any BluetoothDevice, completion: @escaping (Bool) -> Void) {

--- a/AirCasting/SDSync/SDSyncController.swift
+++ b/AirCasting/SDSync/SDSyncController.swift
@@ -152,19 +152,18 @@ class SDSyncController {
                     completion(.failure(.mobileSessionsProcessingFailure))
                     return
                 }
+                do {
+                    try self.finishStandaloneSessionIfPresent(completion)
+                } catch {
+                    completion(.failure(.mobileSessionsProcessingFailure))
+                    return
+                }
             }
         } else { Log.info("[SD Sync] There was no mobile directory.") }
         
         if let fixedFilesDirectoryURL = fixedFilesDirectoryURL {
             handleFixedFiles(at: fixedFilesDirectoryURL)
         } else { Log.info("[SD Sync] There was no fixed directory.") }
-        
-        do {
-            try finishStandaloneSessionIfPresent(completion)
-        } catch {
-            completion(.failure(.mobileSessionsProcessingFailure))
-            return
-        }
         
         Log.info("[SD Sync] Completion success.")
         completion(.success(()))

--- a/AirCasting/SDSync/SDSyncController.swift
+++ b/AirCasting/SDSync/SDSyncController.swift
@@ -120,7 +120,9 @@ class SDSyncController {
     fileprivate func finishStandaloneSessionIfPresent(_ completion: (Result<Void, SDSyncError>) -> Void) throws {
         if let uuidOfSessionToFinish = standaloneSessionToSyncAndFinish?.uuid {
             try finishStandaloneSession(uuid: uuidOfSessionToFinish)
-            standaloneSessionToSyncAndFinish?.clearSessionUuid()
+            DispatchQueue.main.async {
+                self.standaloneSessionToSyncAndFinish?.clearSessionUuid()
+            }
         } else { Log.info("[SD Sync] There was no standalone session to finish.") }
         self.onCurrentSyncEnd { self.startBackendSync() }
     }

--- a/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SDSyncViewModel.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SDSyncViewModel.swift
@@ -17,7 +17,7 @@ protocol SDSyncViewModel: ObservableObject {
     var shouldDismiss: Bool { get set }
     var alert: AlertInfo? { get set }
     var progress: Published<SDSyncProgressViewModel?>.Publisher { get }
-    func connectToAirBeamAndSync()
+    func connectToAirBeamAndSync(_ standaloneSessionToSyncAndFinish: StandaloneSessionToSyncAndFinish)
 }
 
 // [RESOLVER] Move this VM init to view afte all dependencies are resolved
@@ -42,7 +42,7 @@ class SDSyncViewModelDefault: SDSyncViewModel, ObservableObject {
         self.sessionContext = sessionContext
     }
 
-    func connectToAirBeamAndSync() {
+    func connectToAirBeamAndSync(_ standaloneSessionToSyncAndFinish: StandaloneSessionToSyncAndFinish) {
         self.airBeamConnectionController.connectToAirBeam(device: device) { result in
             Log.info("[SD SYNC] Completed connecting to AB")
             guard result == .success else {
@@ -53,7 +53,9 @@ class SDSyncViewModelDefault: SDSyncViewModel, ObservableObject {
                 return
             }
             
-            self.sdSyncController.syncFromAirbeam(self.device, progress: { [weak self] newStatus in
+            self.sdSyncController.syncFromAirbeam(standaloneSessionToSyncAndFinish: standaloneSessionToSyncAndFinish,
+                                                  self.device,
+                                                  progress: { [weak self] newStatus in
                 guard let self = self else { return }
                 switch newStatus {
                 case .inProgress(let progress):

--- a/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SyncingABView.swift
+++ b/AirCasting/SDSync/ViewsFlow/SDSyncingAB/SyncingABView.swift
@@ -11,6 +11,7 @@ struct SyncingABView<VM: SDSyncViewModel>: View {
     @StateObject var viewModel: VM
     @State var progressTitle: String?
     @State var progressCount: String?
+    @EnvironmentObject private var standaloneSessionToSyncAndFinish: StandaloneSessionToSyncAndFinish
     @Binding var creatingSessionFlowContinues: Bool
 
     var body: some View {
@@ -46,7 +47,7 @@ struct SyncingABView<VM: SDSyncViewModel>: View {
              It resulted with showing next view and going back to this one.
              The async enables app to load this view and then push the next one. */
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
-                viewModel.connectToAirBeamAndSync()
+                viewModel.connectToAirBeamAndSync(standaloneSessionToSyncAndFinish)
             }
         })
     }

--- a/AirCasting/SessionViews/StandaloneSessionCardView.swift
+++ b/AirCasting/SessionViews/StandaloneSessionCardView.swift
@@ -9,6 +9,7 @@ struct StandaloneSessionCardView: View {
     let session: SessionEntity
     @EnvironmentObject private var tabSelection: TabBarSelector
     @EnvironmentObject private var finishAndSyncButtonTapped: FinishAndSyncButtonTapped
+    @EnvironmentObject private var standaloneSessionToSyncAndFinish: StandaloneSessionToSyncAndFinish
     @EnvironmentObject var selectedSection: SelectedSection
     @Injected private var networkChecker: NetworkChecker
     @InjectedObject private var userSettings: UserSettings
@@ -87,6 +88,7 @@ struct StandaloneSessionCardView: View {
 
     func finishSessionAndSyncAlertAction() {
         finishAndSyncButtonTapped.finishAndSyncButtonWasTapped = true
+        standaloneSessionToSyncAndFinish.uuid = session.uuid
         tabSelection.update(to: .createSession)
         selectedSection.mobileSessionWasFinished = true
     }

--- a/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
+++ b/AirCasting/SessionsSynchronization/Adapters/DataStore/SessionSynchronizationDatabase.swift
@@ -25,7 +25,11 @@ final class SessionSynchronizationDatabase: SessionSynchronizationStore {
     
     func getLocalSessionList() -> AnyPublisher<[SessionsSynchronization.Metadata], Error> {
         Future { [sessionsFetcher, dataConverter] promise in
-            let predicate = NSPredicate(format: "locationless = %d", false)
+            let predicate = NSPredicate(
+              format: "locationless = %d AND status = %d",
+              false,
+              SessionStatus.FINISHED.rawValue
+            )
             sessionsFetcher.fetchSessions(constrained: .predicate(predicate)) { [dataConverter] result in
                 switch result {
                 case .failure(let error):

--- a/AirCasting/TabBar/MainTabBarView.swift
+++ b/AirCasting/TabBar/MainTabBarView.swift
@@ -17,6 +17,7 @@ struct MainTabBarView: View {
     @StateObject var searchAndFollow = SearchAndFollowButton()
     @StateObject var emptyDashboardButtonTapped = EmptyDashboardButtonTapped()
     @StateObject var finishAndSyncButtonTapped = FinishAndSyncButtonTapped()
+    @StateObject var standaloneSessionToSyncAndFinish = StandaloneSessionToSyncAndFinish()
     @StateObject var exploreSessionsButton = ExploreSessionsButton()
     @StateObject var sessionContext: CreateSessionContext
     @StateObject var coreDataHook: CoreDataHook
@@ -58,6 +59,7 @@ struct MainTabBarView: View {
         .environmentObject(tabSelection)
         .environmentObject(emptyDashboardButtonTapped)
         .environmentObject(finishAndSyncButtonTapped)
+        .environmentObject(standaloneSessionToSyncAndFinish)
         .environmentObject(exploreSessionsButton)
         .environmentObject(reorderButton)
         .environmentObject(searchAndFollow)
@@ -228,6 +230,18 @@ class ExploreSessionsButton: ObservableObject {
 
 class FinishAndSyncButtonTapped: ObservableObject {
     @Published var finishAndSyncButtonWasTapped = false
+}
+
+class StandaloneSessionToSyncAndFinish: ObservableObject {
+    @Published var uuid: SessionUUID?
+    
+    func setSession(_ sessionUuid: SessionUUID?) {
+        uuid = sessionUuid
+    }
+    
+    func clearSessionUuid() {
+        uuid = nil
+    }
 }
 
 class ReorderButton: ObservableObject {

--- a/AirCasting/Utils/Concurrency.swift
+++ b/AirCasting/Utils/Concurrency.swift
@@ -1,0 +1,30 @@
+// Created by Lunar on 9.06.25.
+//
+
+import Foundation
+
+func waitFor<T>(_ operation: @escaping () async throws -> T) throws -> T {
+    guard !Thread.isMainThread else {
+        fatalError("You should not block the main thread waiting for async code.")
+    }
+    var result: T!
+    var caughtError: Error?
+
+    let semaphore = DispatchSemaphore(value: 0)
+
+    Task {
+        do {
+            result = try await operation()
+        } catch {
+            caughtError = error
+        }
+        semaphore.signal()
+    }
+
+    semaphore.wait()
+
+    if let error = caughtError {
+        throw error
+    }
+    return result
+}

--- a/AppDelegate+Injection.swift
+++ b/AppDelegate+Injection.swift
@@ -197,6 +197,8 @@ extension Resolver: ResolverRegistering {
         main.register { SDCardMobileSessionsSavingService() as SDCardMobileSessionssSaver }
         main.register { UploadFixedSessionAPIService() }
         main.register { SDCardFixedSessionsUploadingService() }
+        main.register { SDSyncMobileSessionsDatabaseStorage() }
+        main.register { SDCardMobileSessionFinisher() as SessionFinisher }
         main.register { (_, args) in SDSyncFileValidationService(type: args()) as SDSyncFileValidator }
         
         main.register { SDSyncFileWritingService(bufferThreshold: 1000) as SDSyncFileWriter }


### PR DESCRIPTION
Contains fixes for:
* [Unnecessary Create session API calls](https://trello.com/c/CYQH40Qo/947-create-session-endpoint-being-called-lots-of-times-unnecessarily)
* [ABMini mobile session not getting finished during SD sync if it's under one minute and ABMini standalone mode has been under one minute too](https://trello.com/c/yhm8IIcv/948-ab-mini-mobile-session-cant-sync-finish-when-quickly-entering-standalone-and-attempting-sd-sync)