### PR TITLE
fix/abm-sd-sync-stuck-geolocation

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -4078,7 +4078,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
@@ -4088,7 +4088,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.21.0;
+				MARKETING_VERSION = 1.22.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4106,7 +4106,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4115,7 +4115,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.21.0;
+				MARKETING_VERSION = 1.22.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4194,7 +4194,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4203,7 +4203,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.21.0;
+				MARKETING_VERSION = 1.22.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -4078,7 +4078,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
@@ -4106,7 +4106,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4194,7 +4194,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;

--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeView.swift
@@ -68,8 +68,7 @@ struct ChooseSessionTypeView: View {
                         }, set: { new in
                             viewModel.setLocationLink(using: new)
                         }),
-                                           viewModel: TurnOnLocationViewModel(sessionContext: viewModel.passSessionContext,
-                                                                              isSDClearProcess: false))
+                                           viewModel: TurnOnLocationViewModel(process: .createSession(sessionContext: viewModel.passSessionContext)))
                     }
                 }
                 .fullScreenCover(isPresented: .init(get: {
@@ -159,8 +158,7 @@ struct ChooseSessionTypeView: View {
                                     }, set: { new in
                                         viewModel.setLocationLink(using: new)
                                     }),
-                                                       viewModel: TurnOnLocationViewModel(sessionContext: viewModel.passSessionContext,
-                                                                                          isSDClearProcess: false))
+                                                       viewModel: TurnOnLocationViewModel(process: .createSession(sessionContext: viewModel.passSessionContext)))
                                 }
                             }
                         EmptyView()

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
@@ -29,6 +29,7 @@ struct TurnOnLocationView: View {
                 proceedToBluetoothView
                 proceedToSelectDeviceView
                 proceedToRestartABView
+                proceedToUnplugABView
             }
         )
         .onAppear {
@@ -100,6 +101,14 @@ struct TurnOnLocationView: View {
         NavigationLink(
             destination: SDRestartABView(isSDClearProcess: viewModel.isSDClearProcess, creatingSessionFlowContinues: $creatingSessionFlowContinues),
             isActive: $viewModel.restartABLink,
+            label: {
+                EmptyView()
+            })
+    }
+    var proceedToUnplugABView: some View {
+        NavigationLink(
+            destination: UnplugABView(isSDClearProcess: viewModel.isSDClearProcess, creatingSessionFlowContinues: $creatingSessionFlowContinues),
+            isActive: $viewModel.unplugABLink,
             label: {
                 EmptyView()
             })

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationViewModel.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationViewModel.swift
@@ -4,62 +4,64 @@
 import Foundation
 import Resolver
 
+enum TurnOnLocationUiProcess {
+    case sdClear
+    case sdSync
+    case createSession(sessionContext: CreateSessionContext)
+}
+
 // [RESOLVER] Init this VM inside View
 class TurnOnLocationViewModel: ObservableObject {
     @Published var isPowerABLinkActive = false
     @Published var isTurnBluetoothOnLinkActive = false
     @Published var isMobileLinkActive = false
     @Published var restartABLink = false
+    @Published var unplugABLink = false
     @Published var alert: AlertInfo?
-    var isSDClearProcess: Bool
-
+    
     @Injected private var locationAuthorization: LocationAuthorization
     @Injected private var bluetoothHandler: BluetoothPermisionsChecker
-    private let sessionContext: CreateSessionContext
+    
+    private let process: TurnOnLocationUiProcess
+    
+    init(process: TurnOnLocationUiProcess) {
+        self.process = process
+    }
+    
+    var isSDClearProcess: Bool {
+        return if case .sdClear = process { true } else { false }
+    }
     
     var shouldShowAlert: Bool {
         locationAuthorization.locationState == .denied
-    }
-    
-    var isMobileSession: Bool {
-        sessionContext.sessionType == .mobile
-    }
-    
-    var getSessionContext: CreateSessionContext {
-        sessionContext
-    }
-    
-    init(sessionContext: CreateSessionContext, isSDClearProcess: Bool) {
-        self.sessionContext = sessionContext
-        self.isSDClearProcess = isSDClearProcess
     }
     
     func requestLocationAuthorisation() {
         locationAuthorization.requestAuthorization()
     }
     
-    func checkIfBluetoothDenied() -> Bool {
-       bluetoothHandler.isBluetoothDenied()
-    }
-    
     func onButtonClick() {
-        switch shouldShowAlert {
-        case true:
-            alert = InAppAlerts.locationAlert()
-        case false:
-            locationOnStep()
+        if shouldShowAlert {
+            showRequestLocationAlert()
+        } else {
+            switch process {
+            case .sdClear:
+                restartABLink.toggle()
+            case .sdSync:
+                unplugABLink.toggle()
+            case .createSession(let sessionContext):
+                if sessionContext.isMobileSession {
+                    isMobileLinkActive = true
+                } else if bluetoothHandler.isBluetoothDenied() {
+                    isTurnBluetoothOnLinkActive = true
+                } else {
+                    isPowerABLinkActive.toggle()
+                }
+            }
         }
     }
     
-    private func locationOnStep() {
-        isMobileSession ? isMobileLinkActive = true : notMobileSessionStep()
-    }
-    
-    private func notMobileSessionStep() {
-        checkIfBluetoothDenied() ? isTurnBluetoothOnLinkActive = true : SDClearProcess()
-    }
-    
-    private func SDClearProcess() {
-        isSDClearProcess ? restartABLink.toggle() : isPowerABLinkActive.toggle()
+    private func showRequestLocationAlert() {
+        alert = InAppAlerts.locationAlert()
     }
 }

--- a/AirCasting/Models/SessionContext.swift
+++ b/AirCasting/Models/SessionContext.swift
@@ -42,4 +42,7 @@ final class CreateSessionContext: ObservableObject {
     func saveCurrentLocation(lat: Double, log: Double) {
         startingLocation = CLLocationCoordinate2D(latitude: lat, longitude: log)
     }
+    var isMobileSession: Bool {
+        sessionType == .mobile
+    }
 }

--- a/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedView.swift
+++ b/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedView.swift
@@ -26,7 +26,7 @@ struct BackendSyncCompletedView<VM: BackendSyncCompletedViewModel>: View {
                 }
                 continueButton
             }
-            .background(Group { restartNavigationLink; BTNavigationLink })
+            .background(Group { restartNavigationLink; BTNavigationLink; locationNavigationLink })
             .padding()
             .background(Color.aircastingBackground.ignoresSafeArea())
         }
@@ -60,6 +60,15 @@ private extension BackendSyncCompletedView {
         }
         .buttonStyle(BlueButtonStyle())
         .padding(.bottom, 15)
+    }
+    
+    var locationNavigationLink: some View {
+        NavigationLink(
+            destination: TurnOnLocationView(creatingSessionFlowContinues: $creatingSessionFlowContinues, viewModel: TurnOnLocationViewModel(process: .sdSync)),
+            isActive: .init(get: { viewModel.presentLocationNextScreen }, set: { _ in }),
+            label: {
+                EmptyView()
+            })
     }
     
     var restartNavigationLink: some View {

--- a/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedViewModel.swift
+++ b/AirCasting/SDSync/ViewsFlow/BackendSyncCompleted/BackendSyncCompletedViewModel.swift
@@ -5,6 +5,7 @@ import Foundation
 import Resolver
 
 enum ProceedToSyncView {
+    case locationDenied
     case restart
     case bluetooth
 }
@@ -12,27 +13,34 @@ enum ProceedToSyncView {
 protocol BackendSyncCompletedViewModel: ObservableObject {
     var presentRestartNextScreen: Bool { get }
     var presentBTNextScreen: Bool { get }
-    func continueButtonTapped() 
+    var presentLocationNextScreen: Bool { get }
+    func continueButtonTapped()
 }
 
 class BackendSyncCompletedViewModelDefault: BackendSyncCompletedViewModel, ObservableObject {
     
     @Published var presentRestartNextScreen: Bool = false
     @Published var presentBTNextScreen: Bool = false
+    @Published var presentLocationNextScreen: Bool = false
     @Injected private var bluetoothHandler: BluetoothPermisionsChecker
+    @Injected private var locationAuthorization: LocationAuthorization
     
     func continueButtonTapped() {
         switch sessionNextStep() {
-        case .bluetooth: procedToBTScreen()
-        case .restart: procedToRestartScreen()
+        case .locationDenied: proceedToLocationScreen()
+        case .bluetooth: proceedToBTScreen()
+        case .restart: proceedToRestartScreen()
         }
     }
     
-    private func procedToBTScreen() { presentBTNextScreen.toggle() }
+    private func proceedToBTScreen() { presentBTNextScreen.toggle() }
     
-    private func procedToRestartScreen() { presentRestartNextScreen.toggle() }
+    private func proceedToRestartScreen() { presentRestartNextScreen.toggle() }
+    
+    private func proceedToLocationScreen() { presentLocationNextScreen.toggle() }
     
     private func sessionNextStep() -> ProceedToSyncView {
+        guard locationAuthorization.locationState == .granted else { return .locationDenied }
         guard !bluetoothHandler.isBluetoothDenied() else { return .bluetooth }
         return .restart
     }

--- a/AirCasting/Settings/SettingsView.swift
+++ b/AirCasting/Settings/SettingsView.swift
@@ -31,21 +31,21 @@ struct SettingsView: View {
             .navigationViewStyle(.stack)
             .fullScreenCover(isPresented: $viewModel.startSDClear) {
                 CreatingSessionFlowRootView {
-                    SDRestartABView(isSDClearProcess: viewModel.SDClearingRouteProcess,
+                    SDRestartABView(isSDClearProcess: true,
                                     creatingSessionFlowContinues: $viewModel.startSDClear)
                 }
             }
             .fullScreenCover(isPresented: $viewModel.locationScreenGo) {
                 CreatingSessionFlowRootView {
                     TurnOnLocationView(creatingSessionFlowContinues: $viewModel.locationScreenGo,
-                                       viewModel: TurnOnLocationViewModel(sessionContext: sessionContext, isSDClearProcess: viewModel.SDClearingRouteProcess))
+                                       viewModel: TurnOnLocationViewModel(process: .sdClear))
                 }
             }
             .fullScreenCover(isPresented: $viewModel.BTScreenGo) {
                 CreatingSessionFlowRootView {
                     TurnOnBluetoothView(creatingSessionFlowContinues: $viewModel.BTScreenGo,
                                         sdSyncContinues: .constant(false),
-                                        isSDClearProcess: viewModel.SDClearingRouteProcess)
+                                        isSDClearProcess: true)
                 }
             }
             .environmentObject(viewModel.sessionContext)
@@ -65,7 +65,7 @@ struct SettingsView: View {
                     EmptyView()
                         .fullScreenCover(isPresented: $viewModel.startSDClear) {
                             CreatingSessionFlowRootView {
-                                SDRestartABView(isSDClearProcess: viewModel.SDClearingRouteProcess,
+                                SDRestartABView(isSDClearProcess: true,
                                                 creatingSessionFlowContinues: $viewModel.startSDClear)
                             }
                         }
@@ -73,7 +73,7 @@ struct SettingsView: View {
                         .fullScreenCover(isPresented: $viewModel.locationScreenGo) {
                             CreatingSessionFlowRootView {
                                 TurnOnLocationView(creatingSessionFlowContinues: $viewModel.locationScreenGo,
-                                                   viewModel: TurnOnLocationViewModel(sessionContext: sessionContext, isSDClearProcess: viewModel.SDClearingRouteProcess))
+                                                   viewModel: TurnOnLocationViewModel(process: .sdClear))
                             }
                         }
                     EmptyView()
@@ -81,7 +81,7 @@ struct SettingsView: View {
                             CreatingSessionFlowRootView {
                                 TurnOnBluetoothView(creatingSessionFlowContinues: $viewModel.BTScreenGo,
                                                     sdSyncContinues: .constant(false),
-                                                    isSDClearProcess: viewModel.SDClearingRouteProcess)
+                                                    isSDClearProcess: true)
                             }
                         }
                 })

--- a/AirCasting/Settings/SettingsViewModel.swift
+++ b/AirCasting/Settings/SettingsViewModel.swift
@@ -13,7 +13,6 @@ class SettingsViewModel: ObservableObject {
     @Published var alert: AlertInfo?
     @Published var dormantAlert = false
     
-    var SDClearingRouteProcess = true
     let username = "\(KeychainStorage(service: Bundle.main.bundleIdentifier!).getProfileData(for: .username))"
     
     @Injected private var locationAuthorization: LocationAuthorization

--- a/Readme.md
+++ b/Readme.md
@@ -6,88 +6,60 @@
 
 - [AirCasting](#aircasting)
   * [Conventions](#conventions)
-    + [Marking technical debit](#tech-debit-marking)
+    + [Marking technical debt](#marking-technical-debt)
   * [SwiftLint](#swiftlint)
-  * [Fastlane](#fastlane)
-    + [Beta](#beta)
-    + [Release](#release)
-    + [Release update](#release-update)
+  * [Distributing builds](#Distributing builds)
+    + [Certificates and Profiles setup](#certificates-and-profiles-setup)
+    + [Releasing a Beta build](#releasing-a-beta-build)
+    + [Release](#releasing-an-app-store-build)
   * [Feature Flags](#feature-flags)
   
 ## Conventions
 <a id="tech-debit-marking"></a>
-### Marking technical debit
+### Marking technical debt
 For potential bugs or severe code quality issues:
 1. Place warnings in places that can potentially cause a bug (or bugs), and are too big to resolve ad hoc.
 2. When placing a warning, add a comprehensive explanation of the issue in the comment. Also link the ticket from `3)` in this comment.
 3. Add a ticket to github issues section with correct tag:
     + A "warning" tag for every warning related issue
-    + An "AirBeam needed" tag for issues that reuquire an AirBeam to resolve/reproduce
+    + An "AirBeam needed" tag for issues that require an AirBeam to resolve/reproduce
 
 For less severe stuff like minor code quality issues
 1. When the problem is not causing bug-level issues, but is too big to resolve ad hoc, add a `// FIXME:` marking in code and explain it **really well**, so that someone with more time that stumbles across this will be able to fully understand and refactor/fix. Also link the ticket from `2)` in this comment.
 2. Add a ticket to github issues section with correct tag:
     * A "code quality" tag for quality issues
-    * An "AirBeam needed" tag for issues that reuquire an AirBeam to resolve/reproduce
+    * An "AirBeam needed" tag for issues that require an AirBeam to resolve/reproduce
 
 ## SwiftLint
 We use [swiftlint](https://github.com/realm/SwiftLint) to preserve clean code.
 Please, install it first using Homebrew: `brew install swiftlint`
 
-## Fastlane
-We use [fastlane](https://fastlane.tools) to automate building and releasing our app. Currently we're using 2 paths of release:
-### Beta
-This lane is used for beta releases to the [Firebase Distribution](https://firebase.google.com/docs/app-distribution). In order to deploy a beta build:
-1. `cd` into top project directory
-2. make sure you'll on a `develop` branch and your git status is clean
-3. run `fastlane beta`
-4. after fastlane finsishes you'll find yourself on a version branch `beta/${new_version_number}`. Make a PR out of it and merge it immediately into `develop`  
-
-### Release
-The Release lane will build and release the app to the appstoreconnect and Firebase. Versions released this way will be marked as Release Candidate (RC). To run this lane:
-1. `cd` into top project directory
-2. make sure you're on a `develop` branch and your git status is clean
-3. run `fastlane release`
-4. after fastlane finishes push the release branch to repo, but don't make a PR out of it
-5. bump version number to the next one on `develop` (might need prior consultation with the AC team)
-6. after the version is accepted and released to AppStore merge the release branch into master
-
-<a id="release-update"></a>
-### Release update
-Use the `release_update` lane when you need to add some changes to the release candidate:
-1. `cd` into top project directory
-2. `git checkout` to the release branch (i.e. `release/1.3.0`)
-3. apply and commit changes that are needed. DO NOT cherry-pick commits from develop branch. Remember to merge PRs with fixes directly to the release branch
-4. run `fastlane release_update` 
-
-### Release hotfix
-Use the release hotfix lane when you need to add quick changes to the app that is already in the App Store:
-1. `cd` into top project directory
-2. `git checkout` to the main branch
-3. run `fastlane hotfix_init`. After that you should be checked out to the hotfix branch
-4. apply and commit changes that are needed
-5. run `fastlane hotfix_release`
-6. create PRs to main and to develop branch 
-
-### Bump version after release
-Use the `bump_version_reset_build` lane when you need to increment version number and reset build (to 0) after release is completed:
-1. `cd` into top project directory
-2. make sure you're on a `develop` branch and your git status is clean
-3. run `fastlane bump_version_reset_build`
-4. once the Fastlane finish, push the branch onto remote repo
-5. merge the branch into develop
-
-### Integration
-For the fastlane setup to work you'll need to obtain an `.env.default` file and place it inside Fastlane directory. It contains secret keys used for Firebase communication and appstore connect key details. 
-If you want to integrate the app into your custom setup, provide this file using template:
-```
-FIREBASE_TOKEN = XYZ
-APPSTORE_KEY_ID = XYZ
-APPSTORE_ISSUER_ID = XYZ
-```
-And change the `app` identifier inside Fastfile.
-
-You'll also need an `AuthKey.p8` (an appstoreconnect API key) file placed inside Fastlane directory
+## Distributing builds
+### Certificates and Profiles setup
+Once your Apple ID is added to the project:
+1. Create, download and install (by clicking the downloaded file) into your keychain two types of [certificates](https://developer.apple.com/account/resources/certificates/list):
+   - Apple Development
+   - Apple Distribution
+2. Create, download and install (by clicking the downloaded file) two types of [profiles](https://developer.apple.com/account/resources/profiles/list):
+   - AD Hoc Distribution (connect the aforementioned Apple distribution certificate by selecting it from the list)
+   - App Store distribution
+### Releasing a Beta build
+1. In XCode project navigator select **AirCasting** > **Signing & Capabilities** > **Signing**, verify that the Ad Hoc Distribution provisioning profile is selected
+   * Potential issues
+       - You might need to uncheck **Automatically manage signing** checkbox
+       - You might need to download the profile by going to **XCode** > **Settings** > **Accounts** > **Download Manual Profiles** for HabitatMap Inc.
+2. Set scheme to Beta (**Product** > **Scheme** > **Edit Scheme** > **Archive** > **Build configuration**)
+3. Generate Archive (**Product** > **Archive**)
+4. Go to Archive window, select the generated archive and click **Distribute App** > **Custom** > **Release testing**, go through the wizard, navigate to the generated folder, upload the IPA file to [Firebase distribution](https://console.firebase.google.com/u/0/project/ios-aircasting-app/appdistribution/app/ios:org.habitatmap.AirCasting/releases)
+### Releasing an App Store build
+1. In XCode project navigator select **AirCasting** > **Signing & Capabilities** > **Signing**, verify that the Ad Hoc Distribution provisioning profile is selected
+    * Potential issues
+        - You might need to uncheck **Automatically manage signing** checkbox
+        - You might need to download the profile by going to **XCode** > **Settings** > **Accounts** > **Download Manual Profiles** for HabitatMap Inc.
+2. Set scheme to Release (**Product** > **Scheme** > **Edit Scheme** > **Archive** > **Build configuration**)
+3. Generate Archive (**Product** > **Archive**)
+4. Go to Archive window, select the generated archive and click **Distribute App** > **App Store Connect**, go through the wizard
+5. Select the newly distributed build in [App Store Connect Distribution](https://appstoreconnect.apple.com/apps/1587685281/distribution/ios/version/inflight) and release it
 
 ## Feature Flags
 The app uses a concept called [feature flagging](https://martinfowler.com/articles/feature-toggles.html) to control which parts of code are ready to release and when. We're using [Firebase Remote Config](https://firebase.google.com/docs/remote-config) as a backend for those so we can adjust audiences on the fly not having to release new versions of the app. For beta testers there is a convenient AppSettings view which enables to manually flip any flag.


### PR DESCRIPTION
Contains fix for [ABM SDSync error when not having geolocation permission](https://trello.com/c/I3yGK9Id/949-ab-mini-mobile-session-sd-sync-stuck-in-finalizing). 

When first asked a geolocation permission while recording a session, user can choose "Allow once". Then, when performing SD Sync, the app didn't ask for the geolocation permission but it needed it in the flow, which produced error and couldn't finish SD syncing the session.

The fix adds "Enable geolocation " screen to the SD sync flow if the app doesn't have it, so it works in the same way as when recording a new session or clearing SD card from the settings.

The changes also contain a minor refactor of TurnOnLocationViewModel and updated README for the distribution procedures