### PR TITLE
fix/abm-sd-sync-stuck-geolocation

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -4078,7 +4078,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
@@ -4088,7 +4088,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.22.0;
+				MARKETING_VERSION = 1.22.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4106,7 +4106,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4115,7 +4115,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.22.0;
+				MARKETING_VERSION = 1.22.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4194,7 +4194,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4203,7 +4203,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.22.0;
+				MARKETING_VERSION = 1.22.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeViewModel.swift
+++ b/AirCasting/CreateSessionViews/ChooseSessionType/ChooseSessionTypeViewModel.swift
@@ -55,6 +55,7 @@ class ChooseSessionTypeViewModel: ObservableObject {
     func fixedSessionButtonTapped() {
         createNewSession(isSessionFixed: true)
         switch fixedSessionNextStep() {
+        case.location: isTurnLocationOnLinkActive = true
         case .airBeam: isPowerABLinkActive = true
         case .bluetooth: isTurnBluetoothOnLinkActive = true
         default: return
@@ -95,6 +96,7 @@ class ChooseSessionTypeViewModel: ObservableObject {
     }
     
     private func fixedSessionNextStep() -> ProceedToView {
+        guard locationAuthorization.locationState == .granted else { return .location }
         guard !bluetoothHandler.isBluetoothDenied() else { return .bluetooth }
         return .airBeam
     }

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationView.swift
@@ -81,7 +81,7 @@ struct TurnOnLocationView: View {
     var proceedToBluetoothView: some View {
         NavigationLink(
             destination: TurnOnBluetoothView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
-                                             sdSyncContinues: .constant(false),
+                                             sdSyncContinues: .constant(viewModel.isSDSyncProcess),
                                              isSDClearProcess: viewModel.isSDClearProcess),
             isActive: $viewModel.isTurnBluetoothOnLinkActive,
             label: {
@@ -92,7 +92,7 @@ struct TurnOnLocationView: View {
         NavigationLink(
             destination: SelectDeviceView(creatingSessionFlowContinues: $creatingSessionFlowContinues,
                                           sdSyncContinues: .constant(false)),
-            isActive: $viewModel.isMobileLinkActive,
+            isActive: $viewModel.isProceedToSelectDeviceTypeLinkActive,
             label: {
                 EmptyView()
             })

--- a/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationViewModel.swift
+++ b/AirCasting/CreateSessionViews/TurnOnLocation/TurnOnLocationViewModel.swift
@@ -14,7 +14,7 @@ enum TurnOnLocationUiProcess {
 class TurnOnLocationViewModel: ObservableObject {
     @Published var isPowerABLinkActive = false
     @Published var isTurnBluetoothOnLinkActive = false
-    @Published var isMobileLinkActive = false
+    @Published var isProceedToSelectDeviceTypeLinkActive = false
     @Published var restartABLink = false
     @Published var unplugABLink = false
     @Published var alert: AlertInfo?
@@ -32,6 +32,10 @@ class TurnOnLocationViewModel: ObservableObject {
         return if case .sdClear = process { true } else { false }
     }
     
+    var isSDSyncProcess: Bool {
+        return if case .sdSync = process { true } else { false }
+    }
+    
     var shouldShowAlert: Bool {
         locationAuthorization.locationState == .denied
     }
@@ -45,19 +49,32 @@ class TurnOnLocationViewModel: ObservableObject {
             showRequestLocationAlert()
         } else {
             switch process {
-            case .sdClear:
-                restartABLink.toggle()
-            case .sdSync:
-                unplugABLink.toggle()
+            case .sdClear, .sdSync:
+                handleBluetoothOrToggle(for: process)
+                
             case .createSession(let sessionContext):
                 if sessionContext.isMobileSession {
-                    isMobileLinkActive = true
-                } else if bluetoothHandler.isBluetoothDenied() {
-                    isTurnBluetoothOnLinkActive = true
+                    isProceedToSelectDeviceTypeLinkActive = true
                 } else {
-                    isPowerABLinkActive.toggle()
+                    handleBluetoothOrToggle(for: process)
                 }
             }
+        }
+    }
+    
+    private func handleBluetoothOrToggle(for process: TurnOnLocationUiProcess) {
+        if bluetoothHandler.isBluetoothDenied() {
+            isTurnBluetoothOnLinkActive = true
+            return
+        }
+        
+        switch process {
+        case .sdClear:
+            restartABLink.toggle()
+        case .sdSync:
+            unplugABLink.toggle()
+        case .createSession:
+            isPowerABLinkActive.toggle()
         }
     }
     


### PR DESCRIPTION
This addresses the issue  found in build 1.22.0 with Bluetooth screen not showing during Sync and Clear SD flows;

It also addresses the issue with Location screen not showing during Create a Fixed session flow, which had been present in the app in the earlier versions too