### PR TITLE
fix/finish-recording-dialog-action-not-triggered

### DIFF
--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -23,7 +23,6 @@ struct SessionHeaderView: View {
     @Environment(\.colorScheme) var colorScheme
     @ObservedObject var session: SessionEntity
     @State private var showingNoConnectionAlert = false
-    @State private var alert: AlertInfo?
     @InjectedObject private var featureFlagsViewModel: FeatureFlagsViewModel
     @State var showDeleteModal = false
     @State var showAddNoteModal = false
@@ -31,7 +30,8 @@ struct SessionHeaderView: View {
     @State var showEditView = false
     @State var detectEmailSent = false
     @State var showThresholdAlertModal = false
-    @State private var showFinishSessionAlert = false
+    @State private var isShowingFinishSessionAlert = false
+    @State private var isShowingEmailSentAlert = false
     
     var body: some View {
         if #available(iOS 15, *) {
@@ -51,7 +51,7 @@ struct SessionHeaderView: View {
                                                 }
                                             })).onDisappear(perform: {
                                                 if detectEmailSent {
-                                                    alert = InAppAlerts.shareFileRequestSent()
+                                                    isShowingEmailSentAlert = true
                                                 }
                                             })
                     }
@@ -82,7 +82,7 @@ struct SessionHeaderView: View {
                                     ShareSessionView(viewModel: DefaultShareSessionViewModel(session: session, apiClient: ShareSessionApi(), exitRoute: { result in
                                         showShareModal.toggle()
                                         if result == .fileShared {
-                                            alert = InAppAlerts.shareFileRequestSent()
+                                            isShowingEmailSentAlert = true
                                         }
                                     }))
                                 }
@@ -123,11 +123,7 @@ struct SessionHeaderView: View {
 
 private extension SessionHeaderView {
     var sessionHeader: some View {
-        let finishSessionAlertInfo = InAppAlerts.finishSessionAlert(sessionName: session.name, action: {
-            self.finishSessionAlertAction()
-        })
-        
-        return VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: 3) {
             HStack {
                 SessionTimeView(session: session)
                     .font(Fonts.moderateRegularHeading4)
@@ -137,7 +133,14 @@ private extension SessionHeaderView {
             }
             nameLabelAndExpandButton
         }
-        .alert(finishSessionAlertInfo, $showFinishSessionAlert)
+        .alert(
+            InAppAlerts.finishSessionAlert(
+                sessionName: session.name,
+                action: { self.finishSessionAlertAction() }
+            ),
+            $isShowingFinishSessionAlert
+        )
+        .alert(InAppAlerts.shareFileRequestSent(), $isShowingEmailSentAlert)
         .foregroundColor(.aircastingGray)
     }
     
@@ -198,7 +201,7 @@ private extension SessionHeaderView {
     
     var actionsMenuStopButton: some View {
         Button {
-            showFinishSessionAlert = true
+            isShowingFinishSessionAlert = true
         } label: {
             Label(Strings.SessionHeaderView.stopRecordingButton, systemImage: "stop.circle")
         }

--- a/AirCasting/SessionViews/SessionHeaderView.swift
+++ b/AirCasting/SessionViews/SessionHeaderView.swift
@@ -31,6 +31,7 @@ struct SessionHeaderView: View {
     @State var showEditView = false
     @State var detectEmailSent = false
     @State var showThresholdAlertModal = false
+    @State private var showFinishSessionAlert = false
     
     var body: some View {
         if #available(iOS 15, *) {
@@ -122,7 +123,11 @@ struct SessionHeaderView: View {
 
 private extension SessionHeaderView {
     var sessionHeader: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        let finishSessionAlertInfo = InAppAlerts.finishSessionAlert(sessionName: session.name, action: {
+            self.finishSessionAlertAction()
+        })
+        
+        return VStack(alignment: .leading, spacing: 3) {
             HStack {
                 SessionTimeView(session: session)
                     .font(Fonts.moderateRegularHeading4)
@@ -132,7 +137,7 @@ private extension SessionHeaderView {
             }
             nameLabelAndExpandButton
         }
-        .alert(item: $alert, content: { $0.makeAlert() })
+        .alert(finishSessionAlertInfo, $showFinishSessionAlert)
         .foregroundColor(.aircastingGray)
     }
     
@@ -193,9 +198,7 @@ private extension SessionHeaderView {
     
     var actionsMenuStopButton: some View {
         Button {
-            alert = InAppAlerts.finishSessionAlert(sessionName: session.name, action: {
-                self.finishSessionAlertAction()
-            })
+            showFinishSessionAlert = true
         } label: {
             Label(Strings.SessionHeaderView.stopRecordingButton, systemImage: "stop.circle")
         }

--- a/AirCasting/Utils/InAppAlerts.swift
+++ b/AirCasting/Utils/InAppAlerts.swift
@@ -474,3 +474,19 @@ extension AlertInfo {
         }
     }
 }
+
+extension View {
+    nonisolated func alert(_ alertInfo: AlertInfo, _ isPresented: Binding<Bool>) -> some View {
+        self.alert(alertInfo.title, isPresented: isPresented) {
+            ForEach(Array(alertInfo.buttons.enumerated()), id: \.offset) { index, type in
+                switch type {
+                case .cancel(let title): Button(title, role: .cancel, action: { isPresented.wrappedValue = false })
+                case .default(let title, nil): Button(title, action: { isPresented.wrappedValue = false })
+                case .default(let title, let action): Button(title, action: action!)
+                }
+            }
+        } message: {
+            Text(alertInfo.message)
+        }
+    }
+}


### PR DESCRIPTION
Contains fix for [having to tap Finish recording button on the dialog several times for it to work](https://trello.com/c/tR1QU583/946-mobile-ab-session-graph-finish-recording-must-tap-finish-recording-2-or-3-times-before-action-is-triggered)

Updates usages of Deprecated Alert API for Confirm finish recording and Email sent successfully alerts