### PR TITLE
fix/new-fixed-session-not-deleted-on-other-devices

### DIFF
--- a/AirCasting.xcodeproj/project.pbxproj
+++ b/AirCasting.xcodeproj/project.pbxproj
@@ -4094,7 +4094,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
@@ -4104,7 +4104,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.24.0;
+				MARKETING_VERSION = 1.24.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4122,7 +4122,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4131,7 +4131,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.24.0;
+				MARKETING_VERSION = 1.24.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4210,7 +4210,7 @@
 				CODE_SIGN_ENTITLEMENTS = AirCasting/AirCasting.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = LXAGXH6CF6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = AirCasting/Info.plist;
@@ -4219,7 +4219,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.24.0;
+				MARKETING_VERSION = 1.24.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.habitatmap.AirCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AirCasting/Models/AirBeamCellularSessionCreator.swift
+++ b/AirCasting/Models/AirBeamCellularSessionCreator.swift
@@ -36,7 +36,9 @@ final class AirBeamCellularSessionCreator: SessionCreator {
                               startTime: DateBuilder.getFakeUTCDate(),
                               followedAt: DateBuilder.getFakeUTCDate(),
                               isIndoor: isIndoor,
-                              tags: sessionContext.sessionTags)
+                              tags: sessionContext.sessionTags,
+                              status: .FINISHED
+        )
         
         // if session is fixed: create an empty session on server,
         // then send AB auth data to connect to web session and data needed to start recording

--- a/AirCasting/Models/AirBeamFixedWifiSessionCreator.swift
+++ b/AirCasting/Models/AirBeamFixedWifiSessionCreator.swift
@@ -40,7 +40,9 @@ final class AirBeamFixedWifiSessionCreator: SessionCreator {
                               startTime: DateBuilder.getFakeUTCDate(),
                               followedAt: DateBuilder.getFakeUTCDate(),
                               isIndoor: isIndoor,
-                              tags: sessionContext.sessionTags)
+                              tags: sessionContext.sessionTags,
+                              status: .FINISHED
+        )
         
         // if session is fixed: create an empty session on server,
         // then send AB auth data to connect to web session and data needed to start recording


### PR DESCRIPTION
Contains fixes for [this ticket](https://trello.com/c/Jxw1K8b2/953-ios-record-fixed-sessions-delete-fixed-session-session-doesnt-delete-from-website-or-android)

This changes Fixed sessions status to Finished when creating them (instead of nil value), so that they are accessible during sessions BE sync and can be marked as DELETED in the request (this is in line with what's already happening in the app - it marks the Fixed sessions that it doesn't have that are coming from the BE as Finished)